### PR TITLE
Promote Solana V1 transfers; retire V1 instructions APIs; deepen Solana V1 docs for SEO

### DIFF
--- a/docs/Examples/Solana/_category_.json
+++ b/docs/Examples/Solana/_category_.json
@@ -2,6 +2,17 @@
   "label": "Solana",
   "link": {
     "type": "generated-index",
-    "description": "Using queries in different applications"
+    "title": "Solana API Examples — Bitquery GraphQL",
+    "description": "Production-ready GraphQL examples for Solana on Bitquery V1: full historical SOL and SPL transfers, transactions, addresses, and Coinpath. Built for accounting, tax, audit, trading research, compliance, treasury, and bulk export to S3 in Parquet.",
+    "keywords": [
+      "Solana API",
+      "Solana GraphQL examples",
+      "Solana transfers",
+      "Solana transactions",
+      "Solana address",
+      "Solana historical data",
+      "SPL token",
+      "Bitquery"
+    ]
   }
 }

--- a/docs/Examples/Solana/address-api.md
+++ b/docs/Examples/Solana/address-api.md
@@ -1,18 +1,34 @@
 ---
-title: "Solana Address API Examples — Bitquery GraphQL"
-description: "Example GraphQL queries for Solana addresses. Get balances, annotations, and multi-address lookups."
-keywords: [Solana API examples, Solana GraphQL queries, Bitquery]
+title: "Solana Address API Examples — Wallet Balance, Annotation, Multi-Address"
+description: "Production-ready GraphQL examples for Solana addresses on Bitquery V1: query SOL balance and annotation for one wallet, batch multiple wallets, and pair with full historical transfers for SPL portfolios, accounting, and audit."
+keywords:
+  [
+    "Solana address API",
+    "Solana wallet balance",
+    "Solana SPL portfolio",
+    "Solana annotation",
+    "Solana multi-address",
+    "Bitquery V1",
+    "Solana GraphQL",
+  ]
 ---
 
-# Solana Address API
+# Solana Address API examples
 
-The Solana Address API returns balance, annotation, and address metadata for Solana wallets. Use it for quick balance lookups and multi-address queries.
+The Solana **Address API** on Bitquery V1 returns the latest **SOL balance** and **annotation** for any Solana account, including batched lookups across many wallets in one request. It is the fastest entry point for **wallet directories**, **portfolio dashboards**, **accounting bootstraps**, and **compliance pre-checks** — and it pairs naturally with the [Solana transfers API](/docs/Examples/Solana/transfers) when you need full SPL token portfolios or historical balances.
 
-## Get Latest Solana Address Balance
+## Use cases at a glance {#use-cases}
+
+- **Portfolio and dashboards** — [single-wallet SOL balance](#single-balance), [batched multi-wallet lookup](#multi-balance)
+- **Accounting and audit** — pair with [historical balance at a timestamp](/docs/Examples/Solana/transfers#balance-point-in-time) for end-of-period closing balances
+- **SPL token portfolios** — pair with [per-token balance from transfers](/docs/Examples/Solana/transfers#per-token-sent-received-balance) for full token-level positions
+- **Compliance pre-checks** — verify whether an address has any Bitquery annotation before deeper diligence
+
+## Latest SOL balance for a single Solana address {#single-balance}
 
 Look up the current SOL balance and annotation for a single Solana address. [Run query](https://ide.bitquery.io/address-balance-api).
 
-**Variations:** For SPL token balances, use the [transfers API](/docs/Examples/Solana/transfers) with aggregation instead. Combine with the multi-address query below for batch lookups.
+**Variations:** For SPL token balances, use the [transfers API](/docs/Examples/Solana/transfers#per-token-sent-received-balance) with aggregation. For balance at a specific timestamp or block height, see [historical balance](/docs/Examples/Solana/transfers#balance-point-in-time). Combine with the multi-address query below for batch lookups.
 
 ```
 query MyQuery {
@@ -26,11 +42,11 @@ query MyQuery {
 }
 ```
 
-## Query Multiple Solana Address Balances
+## Batch multi-wallet SOL balance lookup {#multi-balance}
 
-Batch-query SOL balances for multiple Solana addresses in one request using `address: {in: [...]}`. Returns balance and annotation for each address. [Run query](https://ide.bitquery.io/latest-balances-of-multiple-addresses).
+Batch-query SOL balances for multiple Solana addresses in one request using `address: {in: [...]}`. Returns balance and annotation for each address — ideal for treasury dashboards, partner-program reporting, and exchange wallet sets. [Run query](https://ide.bitquery.io/latest-balances-of-multiple-addresses).
 
-**Variations:** Add or remove addresses from the array. Combine with the [transfers API](/docs/Examples/Solana/transfers) for per-token balances across wallets.
+**Variations:** Add or remove addresses from the array. Combine with the [transfers API](/docs/Examples/Solana/transfers#per-token-sent-received-balance) for per-token balances across wallets. For [bubble-map style aggregation across the same wallets](/docs/Examples/Solana/transfers#multi-wallet-aggregates), use the multi-wallet aggregate query in the transfers examples.
 
 ```
 query MyQuery {
@@ -44,10 +60,22 @@ query MyQuery {
 }
 ```
 
+## When to use the Address API vs Transfers {#address-vs-transfers}
+
+| Need                                                      | Use                                                                                            |
+| --------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| Latest SOL balance for one or many wallets                | **Address API** (this page)                                                                    |
+| SPL token balance per wallet/token                        | [Transfers + amount(calculate: sum)](/docs/Examples/Solana/transfers#per-token-sent-received-balance) |
+| Balance at a specific timestamp or block                  | [Historical balance](/docs/Examples/Solana/transfers#balance-point-in-time)                    |
+| Sender or receiver activity history                       | [Transfers (sender/receiver filters)](/docs/Examples/Solana/transfers#wallet-sender-receiver)  |
+| Multi-hop fund flow across addresses                      | [Coinpath](/docs/Schema/solana/coinpath)                                                       |
+
 ## Related Resources
 
-- [Solana schema overview](https://docs.bitquery.io/v1/docs/Schema/solana/overview)
-- [Coinpath explained](https://docs.bitquery.io/v1/docs/building-queries/Coinpath-Explained/Overview)
-- [Getting started with the GraphQL IDE](https://docs.bitquery.io/v1/docs/graphql-ide/how-to-start)
-- [Solana transfers examples](https://docs.bitquery.io/v1/docs/Examples/Solana/transfers)
-- [Bitquery documentation intro](https://docs.bitquery.io/v1/docs/intro)
+- [Solana transfers API examples](/docs/Examples/Solana/transfers) — historical balances, sent/received, multi-wallet aggregates, S3 bulk export
+- [Solana transactions API examples](/docs/Examples/Solana/transactions-api) — fee, signer, success, block context
+- [Solana schema overview](/docs/Schema/solana/overview)
+- [Solana address schema](/docs/Schema/solana/address)
+- [Solana Coinpath schema](/docs/Schema/solana/coinpath)
+- [V1 vs V2 API and cloud data](/docs/graphql-ide/v1-and-v2)
+- [Getting started with the GraphQL IDE](/docs/graphql-ide/how-to-start)

--- a/docs/Examples/Solana/instructions.md
+++ b/docs/Examples/Solana/instructions.md
@@ -1,182 +1,78 @@
 ---
-title: "Solana Instructions API Examples — Bitquery GraphQL"
-description: "Example GraphQL queries for Solana instructions. Get program instructions, actions, logs, and transaction context."
-keywords: [Solana API examples, Solana GraphQL queries, Bitquery]
+title: "Solana Instructions API (Removed in V1) — Use V2 or V1 Alternatives"
+description: "The Solana instructions API has been removed from Bitquery V1. Find equivalents in the V2 API for program/instruction analytics, or use V1 transfers, transactions, and coinpath."
+keywords:
+  [
+    "Solana instructions API",
+    "Bitquery V1",
+    "Solana program analytics",
+    "Solana DEX trades",
+    "Solana V2 API",
+    "Solana transfers",
+    "Solana transactions",
+  ]
 ---
 
-# Solana Instructions Data
+# Solana Instructions Data (Removed in V1)
 
-The Solana Instructions API returns parsed instruction-level data including program names, action types, execution logs, and raw instruction data. Instructions are the atomic operations that make up Solana transactions.
+:::danger Removed in V1 — use the V2 Solana Instructions API
 
-## Recent Solana Instructions with Actions, Programs, and Logs
+The **Solana `instructions` and `instructionAccounts` APIs are no longer available on the V1 endpoint** (`graphql.bitquery.io`). The replacement is the **[V2 Solana Instructions API](https://docs.bitquery.io/docs/blockchain/Solana/solana-instructions/)** at `https://streaming.bitquery.io/graphql`, which provides parsed program/method data, account lists, logs, balance update counts, inner instructions, and real-time WebSocket subscriptions.
 
-Fetch the latest Solana instructions with full details — action name/type, program info, execution logs, external program calls, and raw instruction data. Uses query variables for `limit`, `offset`, and date filtering. [Run query](https://ide.bitquery.io/Solana-Instructions_6).
+:::
 
-**Variations:** Add `parsedActionName` to filter by specific actions. Use `program: {id: {is: "..."}}` to filter by program. Adjust `date` for different periods. Change `limit` and `offset` for pagination.
+## What changed
 
-```
-query ($network: SolanaNetwork!, $limit: Int!, $offset: Int!) {
-  solana(network: $network) {
-    instructions(
-      options: {limit: $limit, offset: $offset, desc: "block.timestamp.time"}
-      date: {since: "2024-12-19"}
-    ) {
-      action {
-        name
-        type
-      }
-      block {
-        hash
-        timestamp {
-          time
-        }
-      }
-      transaction {
-        signature
-        success
-      }
-      program {
-        name
-        parsed
-        parsedName
-        id
-      }
-      log {
-        consumed
-        instruction
-        logs
-        result
-        totalGas
-      }
-      externalAction {
-        name
-        type
-      }
-      externalProgram {
-        id
-        parsed
-        name
-        parsedName
-      }
-      data {
-        hex
-        base58
-      }
-    }
-  }
-}
-{
-  "limit": 100,
-  "offset": 0,
-  "network": "solana"
-}
+Bitquery has retired the V1 instruction-level surface for Solana. Program IDs, parsed action names, instruction logs, inner instructions, and per-instruction account metadata are no longer returned by V1 GraphQL queries against `solana.instructions { ... }` or `solana.instructionAccounts { ... }`.
 
-```
+This page is preserved so existing inbound links and bookmarks resolve to a clear redirection. There are no working queries on this page.
 
-## Find Solana Instructions by Parsed Action Name
+## Recommended alternatives
 
-Filter instructions by a specific parsed action name (e.g., `compactupdatevotestate`) to find all occurrences of that operation across the network. Returns full instruction context including logs and program details. [Run query](https://ide.bitquery.io/Solana-compactupdatevotestate-Action_4).
+### 1) V2 Solana Instructions API (recommended)
 
-**Variations:** Change `parsedActionName` to any Solana action (`transfer`, `mintTo`, `createAccount`, etc.). Add `program: {id: {is: "..."}}` to narrow by program. Use `transaction: {signature: {is: "..."}}` for a specific transaction.
+Use the **[V2 Solana Instructions API](https://docs.bitquery.io/docs/blockchain/Solana/solana-instructions/)** as the direct replacement. It is the supported home for Solana instruction-, program-, and DEX-trade-level analytics, with parsed program IDs, methods, account lists, logs, balance update counts, ancestor indexes, and inner instructions — plus real-time **subscriptions** over WebSockets.
 
-```
-query ($network: SolanaNetwork!, $limit: Int!, $offset: Int!) {
-  solana(network: $network) {
-    instructions(
-      options: {limit: $limit, offset: $offset, desc: "block.height"}
-      date: {since: "2024-12-19"}
-      parsedActionName: {is: "compactupdatevotestate"}
-    ) {
-      action {
-        name
-        type
-      }
-      block {
-        height
-        hash
-        timestamp {
-          time
-        }
-      }
-      transaction {
-        signature
-        success
-      }
-      program {
-        name
-        parsed
-        parsedName
-        id
-      }
-      log {
-        consumed
-        instruction
-        logs
-        result
-        totalGas
-      }
-      externalAction {
-        name
-        type
-      }
-      externalProgram {
-        id
-        parsed
-        name
-        parsedName
-      }
-      data {
-        hex
-        base58
-      }
-    }
-  }
-}
+- **V2 Solana Instructions API:** [`https://docs.bitquery.io/docs/blockchain/Solana/solana-instructions/`](https://docs.bitquery.io/docs/blockchain/Solana/solana-instructions/)
+- **V2 endpoint:** `https://streaming.bitquery.io/graphql`
+- **V2 docs home:** [`https://docs.bitquery.io/`](https://docs.bitquery.io/)
+- **V1 vs V2 reference:** see [V1 and V2 endpoints](/docs/graphql-ide/v1-and-v2)
+- **Try V2 in IDE:** [`https://ide.bitquery.io/explore/EVM`](https://ide.bitquery.io/explore/EVM)
 
-{
-  "limit": 100,
-  "offset": 0,
-  "network": "solana"
-}
-```
-## Recent Solana Transactions After Block Height with Fee and Signer
+What V1 instructions used to cover, in V2 terms:
 
-Get recent Solana transactions after a specific block height and timestamp. Returns fee details, instruction counts (including inner instructions), signer, and success status. [Run query](https://ide.bitquery.io/Recent-Solana-Transactions_1).
+- Solana parsed instructions and inner instructions — [V2 Solana Instructions API](https://docs.bitquery.io/docs/blockchain/Solana/solana-instructions/) (`Solana.Instructions`)
+- Solana DEX trades (parsed swaps, pool, market) — V2 `Solana.DEXTrades`
+- Token balance updates and mint events — V2 `Solana.TokenBalanceUpdates`, `Solana.InstructionBalanceUpdates`
+- Token creation, burn, metadata — see the "Latest Created Tokens", "Track Real-time Token Burn", and "Token Metadata" examples on the [V2 Solana Instructions API](https://docs.bitquery.io/docs/blockchain/Solana/solana-instructions/) page
 
-**Variations:** Adjust `height: {gteq: N}` and the `time` filter for different starting points. Add `signer: {is: "..."}` for a specific wallet. Use `success: false` to find failed transactions.
+### 2) V1 transfers, transactions, and coinpath
 
-```
-query MyQuery {
-  solana(network: solana) {
-    transactions(
-      options: {limit: 10, desc: "block.timestamp.time"}
-      height: {gteq: 286563743}
-    ) {
-      block(time: {after: "2024-12-18T06:30:00Z"}) {
-        timestamp {
-          time
-        }
-        hash
-      }
-      transactionFee
-      transactionIndex
-      signature
-      success
-      signer
-      feePayer
-      accountsCount
-      instructionsCount
-      innerInstructionsCount
-    }
-  }
-}
+If you only need fund-flow, accounting, audit, trading, compliance, or wallet-level analytics, V1 already covers these without instructions:
 
-```
+- [Solana transfers API examples](/docs/Examples/Solana/transfers) — full historical SOL and SPL transfer rows for [accounting and tax](/docs/Examples/Solana/transfers#wallet-sender-receiver), [audit](/docs/Examples/Solana/transfers#parallel-sent-received-range), [trading research](/docs/Examples/Solana/transfers#earliest-mint-transfer), [compliance and forensics](/docs/Examples/Solana/transfers#multi-wallet-aggregates), and [bulk export to S3 + Parquet](/docs/Examples/Solana/transfers#bulk-export-s3-parquet).
+- [Solana transactions API examples](/docs/Examples/Solana/transactions-api) — fee, fee payer, success/failure, signer, instruction count, and block context at the transaction level.
+- [Solana address API examples](/docs/Examples/Solana/address-api) — wallet balance and annotation lookups, including batched multi-address queries.
+- [Solana Coinpath API](/docs/Schema/solana/coinpath) — multi-hop SOL/SPL fund flows for investigation and tracing.
+
+## Mapping V1 instructions concepts to alternatives
+
+| V1 instruction-level need              | Recommended replacement                                                                                                                                                |
+| -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Parsed program / action / logs         | [V2 Solana Instructions API](https://docs.bitquery.io/docs/blockchain/Solana/solana-instructions/) — `Solana.Instructions` (parsed program, method, logs, ancestors)   |
+| DEX swap-level decoding                | V2 `Solana.DEXTrades` (DEX, pool, market, side, price, USD)                                                                                                            |
+| Per-instruction account metas          | [V2 Solana Instructions API](https://docs.bitquery.io/docs/blockchain/Solana/solana-instructions/) — `Solana.Instructions.Accounts` and `Solana.InstructionBalanceUpdates` |
+| Token creation / burn / metadata       | [V2 Solana Instructions API](https://docs.bitquery.io/docs/blockchain/Solana/solana-instructions/) — created tokens, burn tracking, Metaplex metadata examples         |
+| Wallet activity, balance changes       | V1 [transfers](/docs/Examples/Solana/transfers) + [transactions](/docs/Examples/Solana/transactions-api)                                                               |
+| Funding source / first transfer / flow | V1 [transfers](/docs/Examples/Solana/transfers#system-program-funding) + [coinpath](/docs/Schema/solana/coinpath)                                                      |
+| Token mint discovery and history       | V1 [transfers](/docs/Examples/Solana/transfers#earliest-mint-transfer) + V2 `Solana.TokenSupplyUpdates`                                                                |
 
 ## Related Resources
 
-- [Solana schema overview](https://docs.bitquery.io/v1/docs/Schema/solana/overview)
-- [Coinpath explained](https://docs.bitquery.io/v1/docs/building-queries/Coinpath-Explained/Overview)
-- [Getting started with the GraphQL IDE](https://docs.bitquery.io/v1/docs/graphql-ide/how-to-start)
-- [Solana transactions examples](https://docs.bitquery.io/v1/docs/Examples/Solana/transactions-api)
-- [Bitquery documentation intro](https://docs.bitquery.io/v1/docs/intro)
+- **[V2 Solana Instructions API (replacement)](https://docs.bitquery.io/docs/blockchain/Solana/solana-instructions/)**
+- [V1 vs V2 API and cloud data](/docs/graphql-ide/v1-and-v2)
+- [Solana transfers API examples (V1)](/docs/Examples/Solana/transfers)
+- [Solana transactions API examples (V1)](/docs/Examples/Solana/transactions-api)
+- [Solana address API examples (V1)](/docs/Examples/Solana/address-api)
+- [Solana schema overview (V1)](/docs/Schema/solana/overview)
+- [V2 docs home](https://docs.bitquery.io/)

--- a/docs/Examples/Solana/transactions-api.md
+++ b/docs/Examples/Solana/transactions-api.md
@@ -1,18 +1,38 @@
 ---
-title: "Solana Transactions API Examples — Bitquery GraphQL"
-description: "Example GraphQL queries for Solana transactions. Get transactions by time range, fees, instructions, and block context."
-keywords: [Solana API examples, Solana GraphQL queries, Bitquery]
+title: "Solana Transactions API Examples — Fees, Fee Payer, Signers, Block Context"
+description: "Production-ready GraphQL examples for Solana transactions on Bitquery V1: query by date range, signer, fee payer, success/failure, and inner instruction counts. Built for fee analysis, wallet activity, audit, and reporting."
+keywords:
+  [
+    "Solana transactions API",
+    "Solana GraphQL",
+    "Solana fee payer",
+    "Solana signer",
+    "Solana failed transactions",
+    "Solana historical transactions",
+    "Solana audit",
+    "Bitquery V1",
+  ]
 ---
 
-# Solana Transactions API
+# Solana Transactions API examples
 
-The Solana Transactions API returns transaction-level data including fee payer, instruction counts, success status, and block context. Use it for transaction monitoring, fee analysis, and wallet activity tracking.
+The Solana **Transactions API** returns transaction-level data on Bitquery V1 — fee payer, signer, transaction fee, success or failure, instruction and inner-instruction counts, signature, and full block context — across the **entire historical chain**. Use it for **fee analysis**, **wallet activity reporting**, **audit and reconciliation**, **operations dashboards**, and as a complement to the [Solana transfers API](/docs/Examples/Solana/transfers) when you need transaction-level metadata rather than per-transfer rows.
 
-## Get Solana Transactions by Date Range
+> Looking for parsed instructions, program IDs, or DEX swap decoding? Those have moved to the **[V2 Solana Instructions API](https://docs.bitquery.io/docs/blockchain/Solana/solana-instructions/)** — see also [V1 vs V2](/docs/graphql-ide/v1-and-v2).
+
+## Use cases at a glance {#use-cases}
+
+- **Fee analysis and capacity planning** — [transactions in a date range](#date-range), [paid by a specific fee payer](#fee-payer-vs-signer)
+- **Wallet activity and operations** — [a wallet's signed transactions in a window](#wallet-signed-range)
+- **Audit and reconciliation** — pair with [transfers](/docs/Examples/Solana/transfers#parallel-sent-received-range) to attach fees, success status, and signer to every booked movement
+- **Failure analytics and debugging** — [filter to failed transactions](#failed-transactions)
+- **Sponsored transactions** — [find transactions where fee payer ≠ signer](#fee-payer-vs-signer)
+
+## Get Solana transactions in a date range {#date-range}
 
 Fetch Solana transactions within a precise UTC time window. Returns fee payer, instruction counts, success flag, and transaction signature for each transaction. [Run query](https://ide.bitquery.io/transactions-in-a-specific-timeperiod).
 
-**Variations:** Adjust the `time` range as needed. Add `signer: {is: "..."}` to filter by wallet. Use `success: true` to exclude failed transactions. Add [limit/offset](/docs/query-features/filtering/options) for pagination.
+**Variations:** Adjust the `time` range as needed. Add `signer: {is: "..."}` to filter by wallet. Use `success: {is: true}` to exclude failed transactions, or `success: {is: false}` to focus on failures. Add [limit/offset and sort](/docs/query-features/filtering/options) for pagination and ordering.
 
 ```
 query MyQuery {
@@ -39,14 +59,13 @@ query MyQuery {
     }
   }
 }
-
 ```
 
-## Get Solana Address Transactions by Date Range
+## Solana transactions for a wallet (signer) in a date range {#wallet-signed-range}
 
-Get all transactions signed by a specific wallet within a time range using the `signer` filter. Returns instruction counts, fees, success status, and block details. [Run query](https://ide.bitquery.io/transactions-of-an-address-in-a-specific-timeperiod).
+Get all transactions signed by a specific wallet within a time window using the `signer` filter. Returns instruction counts, fees, success status, and block details. Useful for wallet activity reports, billing reconciliation, and per-user analytics. [Run query](https://ide.bitquery.io/transactions-of-an-address-in-a-specific-timeperiod).
 
-**Variations:** Change the `signer` address and `time` range. Add `feePayer: {is: "..."}` if the fee payer differs from the signer. Use `success: false` to find failed transactions.
+**Variations:** Change the `signer` address and `time` range. Add `feePayer: {is: "..."}` if the fee payer differs from the signer. Use `success: {is: false}` to find failed transactions. Combine with the [transfers API](/docs/Examples/Solana/transfers#wallet-sender-receiver) to attach the actual SOL/SPL movements.
 
 ```
 query MyQuery {
@@ -74,13 +93,70 @@ query MyQuery {
     }
   }
 }
+```
 
+## Failed Solana transactions in a window {#failed-transactions}
+
+Filter to **failed** Solana transactions only. Useful for debugging stuck workflows, monitoring contract or relayer health, and surfacing user error patterns. [Open in IDE](https://ide.bitquery.io/).
+
+**Variations:** Add `signer: {is: "..."}` to focus on a single wallet, or `feePayer: {is: "..."}` to track relayer/protocol fee-payer failures. Adjust the `time` window for incident postmortems.
+
+```
+{
+  solana(network: solana) {
+    transactions(
+      time: {since: "2025-07-25T00:00:00Z", till: "2025-07-25T01:00:00Z"}
+      success: {is: false}
+      options: {limit: 50, desc: ["block.height", "transactionIndex"]}
+    ) {
+      block {
+        height
+        timestamp { iso8601 }
+      }
+      signer
+      feePayer
+      transactionFee
+      instructionsCount
+      innerInstructionsCount
+      signature
+      success
+    }
+  }
+}
+```
+
+## Distinguish fee payer from signer {#fee-payer-vs-signer}
+
+Find transactions where the **fee payer** is different from the **signer** — common for sponsored transactions, relayer architectures, and dapp-funded user flows. Useful for cost attribution, treasury controls, and protocol-fee analytics.
+
+**Variations:** Replace the `feePayer` address with your relayer or treasury wallet. Combine with [transfers](/docs/Examples/Solana/transfers#per-token-sent-received-balance) to attribute net flow to the funded users.
+
+```
+{
+  solana(network: solana) {
+    transactions(
+      time: {since: "2025-07-01", till: "2025-07-31"}
+      feePayer: {is: "FeePayerWalletAddressHere"}
+      success: {is: true}
+      options: {limit: 100, desc: ["block.height", "transactionIndex"]}
+    ) {
+      signer
+      feePayer
+      transactionFee
+      signature
+      instructionsCount
+      block { height timestamp { iso8601 } }
+    }
+  }
+}
 ```
 
 ## Related Resources
 
-- [Solana schema overview](https://docs.bitquery.io/v1/docs/Schema/solana/overview)
-- [Coinpath explained](https://docs.bitquery.io/v1/docs/building-queries/Coinpath-Explained/Overview)
-- [Getting started with the GraphQL IDE](https://docs.bitquery.io/v1/docs/graphql-ide/how-to-start)
-- [Solana transfers examples](https://docs.bitquery.io/v1/docs/Examples/Solana/transfers)
-- [Bitquery documentation intro](https://docs.bitquery.io/v1/docs/intro)
+- [Solana transfers API examples](/docs/Examples/Solana/transfers) — full historical SOL and SPL transfer rows, including [bulk export to S3 + Parquet](/docs/Examples/Solana/transfers#bulk-export-s3-parquet)
+- [Solana address API examples](/docs/Examples/Solana/address-api) — wallet balance and multi-address lookups
+- [Solana schema overview](/docs/Schema/solana/overview)
+- [Solana transactions schema](/docs/Schema/solana/transactions)
+- [Solana Coinpath schema](/docs/Schema/solana/coinpath)
+- [V1 vs V2 API and cloud data](/docs/graphql-ide/v1-and-v2) — where Solana instruction- and DEX-level data lives
+- [Getting started with the GraphQL IDE](/docs/graphql-ide/how-to-start)

--- a/docs/Examples/Solana/transfers.md
+++ b/docs/Examples/Solana/transfers.md
@@ -1,58 +1,55 @@
 ---
-title: "Solana Transfers API Examples — Bitquery GraphQL"
-description: "Example GraphQL queries for Solana transfer data. Get SPL and SOL transfers, wallet activity, and token movements."
-keywords: [Solana API examples, Solana GraphQL queries, Bitquery]
+title: "Solana Historical SPL & SOL Transfers API | Bitquery GraphQL"
+description: "Full historical Solana token transfer data via GraphQL: SPL and SOL, wallet balances over time, compliance and audit-style exports. Examples for accounting, tax, trading, and data pipelines."
+keywords:
+  [
+    Bitquery,
+    Solana GraphQL API,
+    Solana SPL token transfers,
+    Solana wallet history,
+    historical Solana transfers,
+    Solana transaction history API,
+    blockchain audit data,
+    Solana compliance analytics,
+    token holder analytics,
+    Parquet export,
+    data warehouse,
+  ]
 ---
 
-# Solana Historical Transfers API
+# Solana historical transfers API
 
-The Solana Historical Transfers API provides comprehensive access to token transfer data on the Solana blockchain, including SPL token transfers, SOL transfers, and detailed transaction information. This API enables real-time monitoring and historical analysis of all transfer activities across the Solana network.
+Bitquery indexes **complete historical** Solana **SOL** and **SPL token** transfers as structured rows you can filter, aggregate, and reconcile—without parsing raw RPC transactions yourself. Teams use this dataset for **accounting** and ledger tie-out, **tax and reporting** pipelines (Bitquery provides movement and USD fields; always apply your jurisdiction’s rules—this is not tax advice), **trading and market** analysis, **compliance** and source-of-funds views, **audit** sampling and evidence bundles (signatures, slots, timestamps), **treasury** monitoring, and **data engineering** (dashboards, ETL, or bulk files). For live streams, see the [Solana streaming docs](https://docs.bitquery.io/docs/blockchain/Solana/).
 
-## What is Solana Transfers API?
+## Use cases at a glance
 
-Bitquery's Solana Transfers API helps you fetch detailed transfer data by writing GraphQL queries. You can track token movements, monitor wallet activities, analyze transfer patterns, and build comprehensive dashboards for Solana-based applications.
+Jump to examples by intent:
 
-## What are the capabilities of Bitquery Solana Transfers API?
+- **Accounting and tax** — [Per-token sent, received, and balance](#per-token-sent-received-balance), [balances up to a point in time](#balance-point-in-time), [parallel sent and received over a date range](#parallel-sent-received-range), [wallet activity in a time window](#wallet-time-range)
+- **Audit and assurance** — [Balances as of a date](#balance-point-in-time), [inflow/outflow at a block height](#block-inflow-outflow), [all transfers in one transaction](#per-signature-transfers); for large populations see [Bulk export (S3 and Parquet)](#bulk-export-s3-parquet)
+- **Trading and research** — [Largest token transfers](#largest-transfers-after-date), [earliest transfer for a mint](#earliest-mint-transfer), [Pump Fun mints by wallet](#pumpfun-mints-by-wallet)
+- **Compliance and investigations** — [Who funded wallets (System Program)](#system-program-funding), [multi-wallet aggregates](#multi-wallet-aggregates), [bubble-map inflows](#bubble-map-inflows), [Coinpath overview](/docs/building-queries/Coinpath-Explained/Overview)
+- **Treasury and operations** — [Wallet as sender or receiver](#wallet-sender-receiver), [historical SOL and stablecoin rows](#historical-sol-stablecoin-rows)
+- **Data products and bulk export** — [Pagination and limits](/docs/query-features/filtering/options), [aggregations](/docs/query-features/aggregation/), [Bulk export (S3 and Parquet)](#bulk-export-s3-parquet)
 
-The Solana Transfers API offers extensive capabilities:
+## What the Solana transfers API gives you
 
-- **Real-time and Historical Data**: Access both live and historical transfer information. For realtime information access the [new streaming Solana docs](https://docs.bitquery.io/docs/blockchain/Solana/)
-- **Comprehensive Filtering**: Filter by wallet addresses, token types, time periods, and transaction signatures
-- **Multi-token Support**: Track SOL, SPL tokens, and custom tokens
-- **Detailed Transaction Data**: Get complete transfer details including amounts, timestamps, and transaction metadata
-- **Balance Tracking**: Calculate wallet balances by analyzing incoming and outgoing transfers
-- **Program Integration**: Identify which Solana programs initiated transfers
-- **Flexible Querying**: Use GraphQL's powerful querying capabilities for complex data retrieval
+- **Historical and streaming** — Full archive for analytics; for realtime use the [streaming Solana docs](https://docs.bitquery.io/docs/blockchain/Solana/) and [subscriptions](https://docs.bitquery.io/docs/subscriptions/websockets/).
+- **Filtering** — Wallets, mints, time, block height, programs, success, amounts, signatures.
+- **Aggregates** — Per-token `sum` / `count`, [expressions](/docs/query-features/expressions/overview) (e.g. net balance), and [sorting](/docs/query-features/filtering/sorting).
+- **Evidence-friendly fields** — Block height, timestamps, transaction signature, program and instruction metadata where indexed.
 
-## Difference between Solana RPC and Bitquery Solana Transfers API?
+## Solana RPC vs Bitquery transfers
 
-**Solana RPC**
+**RPC** — Encoded transactions, heavy parsing, limited turnkey history for analytics.
 
-- Raw transaction data requiring custom parsing
-- No built-in transfer aggregation or filtering
-- Limited historical data access
-- Requires significant development effort for transfer analysis
+**Bitquery** — Pre-parsed transfer rows, filters, aggregates, and time-bounded pulls suited to reporting and monitoring.
 
-**Bitquery Solana Transfers API**
+## Real-time streaming and webhooks
 
-- Pre-parsed, structured transfer data
-- Built-in filtering, aggregation, and historical analysis
-- Real-time streaming capabilities
-- Ready-to-use transfer analytics and monitoring
+You can turn queries into subscriptions for live streams and webhooks. See [WebSocket subscriptions](https://docs.bitquery.io/docs/subscriptions/websockets/), [real-time Solana streams](https://docs.bitquery.io/docs/streams/real-time-solana-data/), and [more Solana API examples](/docs/Examples/Solana/address-api).
 
-## Real-time Streaming and Webhooks
-
-For real-time transfer monitoring, you can convert GraphQL queries to subscriptions for live data streams. This enables:
-
-- **WebSocket Connections**: Monitor transfers in real-time via WebSocket
-- **Webhook Integration**: Set up automated notifications for specific transfer patterns
-- **Live Dashboards**: Build real-time transfer tracking applications
-
-Learn more about [WebSocket subscriptions](https://docs.bitquery.io/docs/subscriptions/websockets/) and [real-time Solana data streams](https://docs.bitquery.io/docs/streams/real-time-solana-data/).
-
-For streaming real-time data, check our [Solana Streaming API docs](https://docs.bitquery.io/v1/docs/examples/Solana)
-
-## Recent Solana Transfers for a Wallet as Sender or Receiver
+## Recent Solana Transfers for a Wallet as Sender or Receiver {#wallet-sender-receiver}
 
 Get the complete transfer history for a Solana wallet — both sent and received — using the `any` filter (OR on `senderAddress` and `receiverAddress`). Returns token details, amounts, timestamps, and transaction signatures. [Run query](https://ide.bitquery.io/Transfers-of-an-address_1).
 
@@ -120,7 +117,7 @@ query MyQuery {
 }
 ```
 
-## Historical Solana Pumpfun Tokens Minted by Wallet from Transfers
+## Historical Solana Pumpfun Tokens Minted by Wallet from Transfers {#pumpfun-mints-by-wallet}
 
 [Run query](https://ide.bitquery.io/get-historical-created-token-and-creator)
 
@@ -283,11 +280,11 @@ query MyQuery {
 }
 ```
 
-## Solana Per-Token Sent, Received, and Balance for an Address
+## Solana Per-Token Sent, Received, and Balance for an Address {#per-token-sent-received-balance}
 
-Calculate per-token balances for a Solana wallet by aggregating all sent and received amounts. Uses `expression(get: "sum_in - sum_out")` to compute the current balance, with separate inbound/outbound counts per token. [Run query](https://ide.bitquery.io/currency-sent-and-received-by-an-address#).
+Calculate per-token balances for a Solana wallet by aggregating all sent and received amounts. Uses `expression(get: "sum_in - sum_out")` to compute the current balance, with separate inbound/outbound counts per token—common for **accounting** tie-out, **treasury** views, and **audit** rollforwards. [Run query](https://ide.bitquery.io/currency-sent-and-received-by-an-address#).
 
-**Variations:** Add `currency: {is: "..."}` for a single token. Include `date` for a time-bounded calculation. Use `amount(in: USD)` for USD-equivalent totals.
+**Variations:** Add `currency: {is: "..."}` for a single token. Bound the period with `date: {since: "...", till: "..."}` or `time: {since: "...", till: "..."}` for tax-year or contract-window totals. Sort with `options: {desc: ["count_in", "count_out"], asc: "currency.symbol"}` when you care about activity counts and alphabetical token order. Use `amount(in: USD)` for USD-equivalent totals. See [aggregation](/docs/query-features/aggregation/) and [options](/docs/query-features/filtering/options).
 
 ```
 query ($address: String!) {
@@ -318,11 +315,11 @@ query ($address: String!) {
 }
 ```
 
-## Solana Wallet Balances per Token Up to a Point in Time
+## Solana Wallet Balances per Token Up to a Point in Time {#balance-point-in-time}
 
-Get a wallet's per-token balances as of a specific date by summing all transfers up to that point. Uses `date: {till: $date}` with the same `sum_in - sum_out` expression pattern — useful for historical snapshots, tax reporting, and point-in-time audits.
+Get a wallet's per-token balances as of a specific date by summing all transfers up to that point. Uses `date: {till: $date}` with the same `sum_in - sum_out` expression pattern—useful for **historical snapshots**, **tax** and regulatory reporting pipelines, and **audit** evidence at a cutoff. The same pattern works with `time: {till: "..."}` for a precise UTC cutoff.
 
-**Variations:** Change the `$date` variable for different snapshot dates. Add `currency: {is: "..."}` for a single token. Add `amount(in: USD)` for USD values.
+**Variations:** Change the `$date` variable for different snapshot dates. Add `currency: {is: "..."}` for a single token. Add `amount(in: USD)` for USD values. Prefer `height` filters (see [block inflow/outflow](#block-inflow-outflow)) when you must align to a slot. Combine with [sorting](/docs/query-features/filtering/sorting) on `balance` or token fields as needed.
 
 [Run query](https://ide.bitquery.io/balance-on-a-specific-date#)
 
@@ -388,7 +385,7 @@ Get a token's holder list with computed balances by aggregating all transfers pe
 }
 ```
 
-## Solana Token Inflows to a Wallet for Bubble Map Charts
+## Solana Token Inflows to a Wallet for Bubble Map Charts {#bubble-map-inflows}
 
 Retrieve all incoming token transfers to a wallet on a specific date with USD amounts — the data needed for bubble map visualizations showing where funds came from. See the full [Solana BubbleMaps guide](https://bitquery.io/blog/solana-bubblemaps-bitquery-zero-rpc).
 
@@ -446,6 +443,300 @@ query TransfersForBubbleMap($since: ISO8601DateTime!, $currency: String, $limit:
 }
 ```
 
+## Solana multi-wallet transfer aggregates (bubble-map style) {#multi-wallet-aggregates}
+
+For **compliance graphs**, **holder-set analytics**, or **bubble-map** style visuals, you often need **aggregated flows between many addresses** (only edges where both sender and receiver are in your set). Filter `senderAddress` and `receiverAddress` with the same `in` list, restrict mints with `currency: {in: $currencies}`, and sum amounts. This pattern scales better than hard-coding dozens of GraphQL variables—pass one address array from your app. See the [Solana BubbleMaps guide](https://bitquery.io/blog/solana-bubblemaps-bitquery-zero-rpc).
+
+**Variations:** Add `success: {is: true}` to drop failed transactions. Tighten `date` for performance. Use [limit/offset](/docs/query-features/filtering/options) to page.
+
+```
+query SolanaMultiWalletAggregates(
+  $addresses: [String!]
+  $currencies: [String!]
+  $count: Int
+  $offset: Int
+  $start_date: ISO8601DateTime
+  $end_date: ISO8601DateTime
+) {
+  solana(network: solana) {
+    transfers(
+      senderAddress: {in: $addresses}
+      receiverAddress: {in: $addresses}
+      currency: {in: $currencies}
+      success: {is: true}
+      options: {limit: $count, offset: $offset}
+      date: {since: $start_date, before: $end_date}
+    ) {
+      sender {
+        address
+      }
+      receiver {
+        address
+      }
+      currency {
+        symbol
+        name
+        address
+      }
+      sum: amount(calculate: sum)
+    }
+  }
+}
+```
+
+```
+{
+  "addresses": [
+    "5Q544fKrFoe6tsEbD7S8EmxGTJYAKtTVhAW5Q5pge4j1",
+    "EwfYTqVjBp1hMrFE8qHR2wdWPJYFtczFXXmfw27cfXgL",
+    "4JKcs9USYFHSwQf473ahXuTXRYCjuBzY4dg21UhdzhFz"
+  ],
+  "currencies": [
+    "-",
+    "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB"
+  ],
+  "count": 25000,
+  "offset": 0,
+  "start_date": "2022-12-10",
+  "end_date": "2023-06-10"
+}
+```
+
+## Parallel Solana sent and received transfers for a wallet (date range) {#parallel-sent-received-range}
+
+**Accounting**, **tax**, and **audit** teams often need **separate ledgers** of outbound vs inbound transfers for the same wallet over a reporting window. Query `sent: transfers(...)` and `received: transfers(...)` in one GraphQL request using field aliases. Below, each branch filters `amount: {gt: 0}` and returns block time, counterparties, USD, and signatures for evidence.
+
+**Variations:** Align `time` on both branches. Add `currency` for one mint. Use `date` instead of `time` for day-level reporting.
+
+```
+query SolanaWalletSentReceivedRange {
+  solana(network: solana) {
+    sent: transfers(
+      options: {desc: "block.height", limit: 1000, offset: 0}
+      senderAddress: {is: "FD4s4MU7o58ReoR97zjM5dWBmY5RF7RSm93G3LZqnzJa"}
+      time: {since: "2025-06-25", till: "2025-07-25"}
+      amount: {gt: 0}
+    ) {
+      block {
+        timestamp {
+          time(format: "%Y-%m-%d %H:%M:%S")
+        }
+        height
+      }
+      sender {
+        address
+        mintAccount
+      }
+      receiver {
+        address
+        mintAccount
+      }
+      currency {
+        name
+        address
+        symbol
+      }
+      amount
+      amount_usd: amount(in: USD)
+      transaction {
+        feePayer
+        signature
+      }
+    }
+    received: transfers(
+      options: {desc: "block.height", limit: 1000, offset: 0}
+      receiverAddress: {is: "FD4s4MU7o58ReoR97zjM5dWBmY5RF7RSm93G3LZqnzJa"}
+      time: {since: "2025-06-25", till: "2025-07-25"}
+      amount: {gt: 0}
+    ) {
+      block {
+        timestamp {
+          time(format: "%Y-%m-%d %H:%M:%S")
+        }
+        height
+      }
+      sender {
+        address
+        mintAccount
+      }
+      receiver {
+        address
+        mintAccount
+      }
+      currency {
+        name
+        address
+        symbol
+      }
+      amount
+      amount_usd: amount(in: USD)
+      transaction {
+        feePayer
+        signature
+      }
+    }
+  }
+}
+```
+
+## Who funded these Solana wallets (System Program) {#system-program-funding}
+
+For **compliance** and **source-of-funds** review, native SOL funding often shows up through the **System Program**. The query below returns early inbound SOL (or system-level) transfers to a small set of receivers, one row per receiver (`limitBy`), ordered by block and transaction index.
+
+**Variations:** Expand `receiverAddress: {in: [...]}`. Adjust `limit` and `limitBy`. Remove `programId` to see all funding assets (may be noisier).
+
+```
+{
+  solana(network: solana) {
+    transfers(
+      receiverAddress: {in: ["9yYya3F5EJoLnBNKW6z4bZvyQytMXzDcpU5D6yYr4jqL", "2WN4rnEmB9c9ouC7VTb4CBXbyiY7qTMcvWUxKKQ2D47T"]}
+      programId: {is: "11111111111111111111111111111111"}
+      options: {limit: 2, asc: ["block.height", "transaction.transactionIndex"], limitBy: {each: "receiver.address", limit: 1}}
+    ) {
+      currency {
+        symbol
+      }
+      instruction {
+        program {
+          id
+        }
+      }
+      sender {
+        address
+      }
+      receiver {
+        address
+        mintAccount
+      }
+      amount
+      transaction {
+        signature
+        transactionIndex
+      }
+      block {
+        height
+        timestamp {
+          unixtime
+        }
+      }
+    }
+  }
+}
+```
+
+## Earliest on-chain transfer for a Solana token mint {#earliest-mint-transfer}
+
+**Trading**, **research**, and **provenance** workflows often need the **first** indexed transfer for a mint (mint creation or first movement). Request `limit: 1` with ascending block and transaction index. Inspect `sender`, `receiver`, and `transaction` (including `signer`) for attribution—not legal proof of “creator” by itself.
+
+**Variations:** Add `date: {since: "..."}` to bound scan cost. Change `currency` to your mint address.
+
+```
+{
+  solana(network: solana) {
+    transfers(
+      date: {since: "2023-05-05"}
+      options: {limit: 1, asc: ["block.height", "transaction.transactionIndex"]}
+      currency: {is: "6p6xgHyF7AeE6TZkSmFsko444wqoP15icUSqi2jfGiPN"}
+    ) {
+      currency {
+        tokenId
+        symbol
+        name
+        address
+      }
+      instruction {
+        program {
+          name
+          id
+        }
+        externalAction {
+          type
+          name
+        }
+      }
+      sender {
+        address
+        type
+        mintAccount
+      }
+      receiver {
+        type
+        mintAccount
+        address
+      }
+      transaction {
+        signature
+        creator: signer
+        transactionIndex
+      }
+      block {
+        height
+        timestamp {
+          iso8601
+        }
+      }
+    }
+  }
+}
+```
+
+## Solana transfers involving the SPL Token program {#spl-token-program-transfers}
+
+Many SPL movements are mediated by the **Token program**. Filter `programId` to **TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA** when you need **accounting** or **audit** samples aligned to standard SPL instruction surfaces (with program and external action metadata).
+
+**Variations:** Swap `programId` for another program (DEX, lending, etc.). Narrow `date` and raise `limit` for larger samples.
+
+```
+{
+  solana(network: solana) {
+    transfers(
+      date: {since: "2023-05-05"}
+      options: {limit: 10, asc: ["block.height", "transaction.transactionIndex"]}
+      programId: {is: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"}
+    ) {
+      currency {
+        tokenId
+        symbol
+        name
+        address
+      }
+      instruction {
+        program {
+          name
+          id
+        }
+        externalAction {
+          type
+          name
+        }
+      }
+      sender {
+        address
+        type
+        mintAccount
+      }
+      receiver {
+        type
+        mintAccount
+        address
+      }
+      transaction {
+        signature
+        creator: signer
+        transactionIndex
+      }
+      block {
+        height
+        timestamp {
+          iso8601
+        }
+      }
+    }
+  }
+}
+```
+
 ## List Solana Token Senders to a Specific Receiver Address
 
 Identify every wallet that sent a specific token to a given receiver address on a particular date. Useful for tracking token sources, verifying payment senders, or investigating inbound fund origins.
@@ -490,7 +781,7 @@ query MyQuery {
 
 ```
 
-## Solana Wallet Inflow and Outflow Transfers at Block Height
+## Solana Wallet Inflow and Outflow Transfers at Block Height {#block-inflow-outflow}
 
 Analyze a wallet's inflow and outflow at a specific block height using [aliases](/docs/query-features/aliases) (`outflow:` and `inflow:`). Shows token details, program info, and sender/receiver types — useful for event-level forensics and block-by-block wallet analysis. [Run query](https://ide.bitquery.io/outflowinflow-of-an-address-on-Solana).
 
@@ -586,7 +877,7 @@ Analyze a wallet's inflow and outflow at a specific block height using [aliases]
 
 ```
 
-## Solana Wallet Transfers Within a Start and End Time Range
+## Solana Wallet Transfers Within a Start and End Time Range {#wallet-time-range}
 
 Get all transfers for a wallet within a precise UTC time window using the `time` filter. Captures both sent and received transfers via the `any` clause — useful for hourly reporting, compliance audits, and time-bounded analysis. [Run query](https://ide.bitquery.io/Transfers-of-a-wallet-for-a-specific-timeperiod).
 
@@ -626,7 +917,7 @@ query MyQuery {
 }
 ```
 
-## Largest Solana Token Transfers by Amount After a Date
+## Largest Solana Token Transfers by Amount After a Date {#largest-transfers-after-date}
 
 Find the biggest transfers for a specific token by sorting with `desc: "amount"`. Surfaces whale movements and large institutional transfers — useful for market impact analysis and whale tracking. [Run query](https://ide.bitquery.io/v1-top-transfers-of-a-solana-token_1).
 
@@ -666,7 +957,7 @@ query MyQuery {
 
 ```
 
-## Solana Wallet Historical SOL and Stablecoin Balances via Transfers
+## Solana Wallet Historical SOL and Stablecoin Balances via Transfers {#historical-sol-stablecoin-rows}
 
 Calculate a wallet's historical SOL and stablecoin balances at a point in time by separately summing sent and received amounts with USD conversion. Uses `time: {till: ...}` to cap the calculation at a specific timestamp. [Run query](https://ide.bitquery.io/solana-money-sent-and-recieved-by-an-address_5).
 
@@ -708,7 +999,7 @@ Calculate a wallet's historical SOL and stablecoin balances at a point in time b
 
 ```
 
-## Solana Transfers for All Instructions in One Transaction Signature
+## Solana Transfers for All Instructions in One Transaction Signature {#per-signature-transfers}
 
 Inspect every transfer inside a single Solana transaction by filtering on `signature`. Returns all token movements, program details, and sender/receiver account types — essential for debugging failed transactions or understanding complex DeFi interactions. [Run query](https://ide.bitquery.io/get-historical-transaction-detail-on-Solana).
 
@@ -819,10 +1110,18 @@ query MyQuery {
 }
 ```
 
+## Bulk export: Solana transfer data (S3 and Parquet) {#bulk-export-s3-parquet}
+
+For **audit**, **regulatory**, and **warehouse** workloads, teams often need **complete historical** transfer rows at scale—not only interactive GraphQL. Bitquery delivers blockchain datasets through **cloud export**, including delivery to **Amazon S3** as **Apache Parquet** for analytics engines (Snowflake, BigQuery, DuckDB, Spark, and similar), retention policies, and ACL-governed buckets. This complements the queries on this page: use GraphQL for targeted samples and dashboards, and bulk files for population-level extracts and workpaper pipelines.
+
+Read how V1 relates to cloud delivery in [V1 vs V2 and data in the cloud](/docs/graphql-ide/v1-and-v2). For product details, see [Data in the cloud / streaming](https://bitquery.io/products/streaming). Contact Bitquery sales or support for availability, scope, and formats for your use case.
+
 ## Related Resources
 
+- [Solana transfers schema (fields and filters)](/docs/Schema/solana/transfers)
 - [Solana schema overview](https://docs.bitquery.io/v1/docs/Schema/solana/overview)
 - [Coinpath explained](https://docs.bitquery.io/v1/docs/building-queries/Coinpath-Explained/Overview)
+- [V1 vs V2 API and cloud data](/docs/graphql-ide/v1-and-v2)
 - [Getting started with the GraphQL IDE](https://docs.bitquery.io/v1/docs/graphql-ide/how-to-start)
 - [Solana address API examples](https://docs.bitquery.io/v1/docs/Examples/Solana/address-api)
 - [Bitquery documentation intro](https://docs.bitquery.io/v1/docs/intro)

--- a/docs/Examples/overview.md
+++ b/docs/Examples/overview.md
@@ -1,18 +1,40 @@
 ---
 title: "Blockchain API Examples — Bitquery GraphQL Query Library"
 sidebar_position: 1
-description: "Browse ready-made GraphQL examples for Bitquery APIs—learn what data you can query and how to call each endpoint."
-keywords: [Bitquery, GraphQL examples, blockchain API, query library, documentation]
+description: "Browse production-ready GraphQL examples for Bitquery V1 across Ethereum, Solana, Bitcoin, Ripple, Tron, and more — built for accounting, audit, trading, compliance, and bulk export to S3 and Parquet."
+keywords:
+  [
+    Bitquery,
+    GraphQL examples,
+    blockchain API,
+    Solana API,
+    Ethereum API,
+    Bitcoin API,
+    Bitquery V1,
+    query library,
+    documentation,
+  ]
 ---
 
-# Overview 
+# Overview
 
-In this section we will see some examples of how to use the different APIs and what data you can get using them.
+This section is a query library for the Bitquery V1 GraphQL API. Each chain page contains production-ready examples that you can run directly in the [GraphQL IDE](/docs/graphql-ide/how-to-start) and adapt for accounting, tax, audit, trading research, compliance, treasury, and bulk data delivery.
+
+## Featured: Solana on V1
+
+Bitquery's V1 Solana surface indexes the **complete historical** chain for SOL and SPL token movement, transactions, addresses, blocks, block rewards, and Coinpath fund-flow tracing. Highlights:
+
+- [Solana transfers API examples](/docs/Examples/Solana/transfers) — full historical SOL and SPL transfers for [accounting and tax](/docs/Examples/Solana/transfers#wallet-sender-receiver), [audit](/docs/Examples/Solana/transfers#parallel-sent-received-range), [trading research](/docs/Examples/Solana/transfers#earliest-mint-transfer), [compliance and forensics](/docs/Examples/Solana/transfers#multi-wallet-aggregates), and [bulk export to S3 + Parquet](/docs/Examples/Solana/transfers#bulk-export-s3-parquet).
+- [Solana transactions API examples](/docs/Examples/Solana/transactions-api) — fee, fee payer, signer, success, and block context.
+- [Solana address API examples](/docs/Examples/Solana/address-api) — wallet balance and batched multi-address lookups.
+
+> Looking for parsed Solana instructions, program IDs, or DEX swap decoding? Those have moved to the **[V2 Solana Instructions API](https://docs.bitquery.io/docs/blockchain/Solana/solana-instructions/)** — see also [V1 vs V2](/docs/graphql-ide/v1-and-v2).
 
 ## Related Resources
 
-- [Bitquery documentation home](https://docs.bitquery.io/v1/docs/intro)
-- [How to start with the GraphQL IDE](https://docs.bitquery.io/v1/docs/graphql-ide/how-to-start)
-- [Ethereum schema overview](https://docs.bitquery.io/v1/docs/Schema/ethereum/overview)
-- [Bitcoin API examples](https://docs.bitquery.io/v1/docs/examples/Bitcoin)
-- [Coinpath explained — overview](https://docs.bitquery.io/v1/docs/building-queries/Coinpath-Explained/Overview)
+- [Bitquery documentation home](/docs/intro)
+- [How to start with the GraphQL IDE](/docs/graphql-ide/how-to-start)
+- [Solana schema overview](/docs/Schema/solana/overview)
+- [Ethereum schema overview](/docs/Schema/ethereum/overview)
+- [Coinpath explained — overview](/docs/building-queries/Coinpath-Explained/Overview)
+- [V1 vs V2 API and cloud data](/docs/graphql-ide/v1-and-v2)

--- a/docs/Schema/solana/address.md
+++ b/docs/Schema/solana/address.md
@@ -1,14 +1,22 @@
 ---
-title: "Solana Address API"
-description: "Solana wallet SOL balance and account annotations—query addresses on Solana with Bitquery GraphQL."
-keywords: ["Solana API", "Solana Address", "Bitquery", "GraphQL"]
+title: "Solana Address API — Wallet SOL Balance, Annotation"
+description: "Query Solana wallet SOL balance and account annotations with Bitquery V1 GraphQL. Use it for wallet directories, portfolio dashboards, accounting bootstraps, and compliance pre-checks."
+keywords:
+  [
+    "Solana address API",
+    "Solana wallet balance",
+    "Solana annotation",
+    "Solana portfolio",
+    "Bitquery V1",
+    "Solana GraphQL",
+  ]
 ---
 
 # Address
 
-The Solana address API gives you information of the balance of a wallet in SOL.
+The Solana **address API** returns the latest **SOL balance** and **annotation** for a Solana account, plus account-level metadata where indexed. Solana addresses (public keys) can be regular wallets, token accounts, or program-derived addresses; this API is the fastest way to fetch balance and label data without traversing transfer history.
 
-Solana addresses (public keys) can be regular wallets, token accounts, or program-derived addresses. The address API returns balance, annotation, and account-level metadata. Use it for wallet lookups, portfolio snapshots, or verifying whether an address is a known entity before diving into transfer or instruction history.
+It is most useful for **wallet directories**, **portfolio dashboards**, **accounting bootstraps** (opening balances), and **compliance pre-checks** (does an address have a Bitquery annotation?). For SPL token portfolios or balance at a specific timestamp/block, pair this API with the [transfers API](/docs/Examples/Solana/transfers).
 
 ```
 query MyQuery {
@@ -20,23 +28,24 @@ query MyQuery {
     }
   }
 }
-
-
 ```
 
+## Common use cases
 
+- **Portfolio and dashboards** — single-wallet SOL balance and batched [multi-address lookups](/docs/Examples/Solana/address-api#multi-balance).
+- **Accounting and audit** — combine current SOL balance with [historical balance from transfers](/docs/Examples/Solana/transfers#balance-point-in-time) for opening/closing positions.
+- **SPL token portfolios** — per-token positions are derived from [transfers + aggregation](/docs/Examples/Solana/transfers#per-token-sent-received-balance).
+- **Compliance pre-checks** — surface any Bitquery annotation on an address before deeper diligence.
 
 <details>
 
 <summary>Filtering Address</summary>
-
 
 `address`:  Specify the address of the wallet. The `is` keyword is used to specify that the address must match the value that is provided.
 
 </details>
 
 ## Fields
-
 
 `address`
 
@@ -50,12 +59,12 @@ Any label on the account.
 
 The balance of the account in SOL.
 
-The balance of the account.
-
 ## Related Resources
 
-- [Solana schema overview](https://docs.bitquery.io/v1/docs/Schema/solana/overview)
-- [Getting started with the GraphQL IDE](https://docs.bitquery.io/v1/docs/graphql-ide/how-to-start)
-- [Coinpath explained](https://docs.bitquery.io/v1/docs/building-queries/Coinpath-Explained/Overview)
-- [Solana Coinpath API](https://docs.bitquery.io/v1/docs/Schema/solana/coinpath)
-- [GraphQL examples overview](https://docs.bitquery.io/v1/docs/Examples/overview)
+- [Solana address examples (V1)](/docs/Examples/Solana/address-api)
+- [Solana transfers schema (V1)](/docs/Schema/solana/transfers) — for SPL token balances, historical balance, and full transfer history
+- [Solana transfers examples (V1)](/docs/Examples/Solana/transfers)
+- [Solana schema overview (V1)](/docs/Schema/solana/overview)
+- [Solana Coinpath API (V1)](/docs/Schema/solana/coinpath)
+- [Getting started with the GraphQL IDE](/docs/graphql-ide/how-to-start)
+- [V1 vs V2 API and cloud data](/docs/graphql-ide/v1-and-v2)

--- a/docs/Schema/solana/blockRewards.md
+++ b/docs/Schema/solana/blockRewards.md
@@ -1,14 +1,23 @@
 ---
-title: "Solana Block Rewards API"
-description: "Query Solana block rewards data using Bitquery GraphQL API. Get block reward distributions, validators, and amounts."
-keywords: ["Solana API", "Solana Block Rewards", "Bitquery", "GraphQL"]
+title: "Solana Block Rewards API — Validator Rewards, Epochs, Reward Type"
+description: "Query Solana block rewards with Bitquery V1 GraphQL: validator and stake account reward distributions per epoch, reward type, post-balance, and currency. Built for staking analytics, validator economics, and yield reporting."
+keywords:
+  [
+    "Solana block rewards API",
+    "Solana validator rewards",
+    "Solana staking rewards",
+    "Solana epoch rewards",
+    "Solana yield",
+    "Bitquery V1",
+    "Solana GraphQL",
+  ]
 ---
 
 # Block Rewards
 
-The BlockRewards API returns information about rewards on the Solana network. Solana implements a proof of stake reward scheme for validator nodes. Rewards are paid every epoch.
+The Solana **BlockRewards API** returns indexed reward distributions on the Solana network. Solana implements a proof-of-stake reward scheme for validator nodes; rewards are paid every epoch and the API exposes the **account** that received the reward, the **rewardType**, **amount**, **currency**, **postBalance**, and full **block** context.
 
-The fields in the schema for blockrewards API include: 
+Use it for **validator economics**, **stake-pool analytics**, **yield reporting** for SOL stakers, **delegated-stake reconciliation**, and to combine with [transactions](/docs/Schema/solana/transactions) for end-to-end performance views.
 
 ```
 query ($network: SolanaNetwork!, $date: ISO8601DateTime, $height: Int) {
@@ -56,18 +65,24 @@ query ($network: SolanaNetwork!, $date: ISO8601DateTime, $height: Int) {
   "dateFormat": "%Y-%m-%d"
 }
 ```
+
+## Common use cases
+
+- **Validator economics and yield reporting** — sum validator rewards by `account` and `rewardType` over an epoch range.
+- **Stake-pool / staker reconciliation** — match rewards to stake accounts and feed accounting systems.
+- **Treasury and tax** — combine block rewards with [transfers](/docs/Examples/Solana/transfers) for income recognition per period.
+- **Network health** — monitor reward issuance trends alongside [block](/docs/Schema/solana/blocks) production.
+
 <details>
 
 <summary>Filtering blockRewards</summary>
 
+`date` The date of the block rewards.
 
+`height` The height of the block rewards.
 
-`date` The date of the block rewards. 
+`blockHash` The hash of the block rewards.
 
-`height` The height of the block rewards. 
-
-`blockHash` The hash of the block rewards. 
- 
 `any` This field can be used to filter the results by any of the other fields in the response (OR logic)
 
 `account` The account address that received the block rewards.
@@ -78,10 +93,9 @@ query ($network: SolanaNetwork!, $date: ISO8601DateTime, $height: Int) {
 
 `parentSlot` The slot number of the parent block.
 
-`rewardType` The type of block rewards. 
+`rewardType` The type of block rewards.
 
 </details>
-
 
 ## Fields
 
@@ -101,8 +115,11 @@ query ($network: SolanaNetwork!, $date: ISO8601DateTime, $height: Int) {
 
 ## Related Resources
 
-- [Solana schema overview](https://docs.bitquery.io/v1/docs/Schema/solana/overview)
-- [Getting started with the GraphQL IDE](https://docs.bitquery.io/v1/docs/graphql-ide/how-to-start)
-- [Coinpath explained](https://docs.bitquery.io/v1/docs/building-queries/Coinpath-Explained/Overview)
-- [Solana Coinpath API](https://docs.bitquery.io/v1/docs/Schema/solana/coinpath)
-- [GraphQL examples overview](https://docs.bitquery.io/v1/docs/Examples/overview)
+- [Solana transfers schema (V1)](/docs/Schema/solana/transfers) — for the SOL/SPL movements that pair with reward income
+- [Solana transfers examples (V1)](/docs/Examples/Solana/transfers)
+- [Solana transactions schema (V1)](/docs/Schema/solana/transactions)
+- [Solana blocks schema (V1)](/docs/Schema/solana/blocks)
+- [Solana schema overview (V1)](/docs/Schema/solana/overview)
+- [Solana Coinpath API (V1)](/docs/Schema/solana/coinpath)
+- [Getting started with the GraphQL IDE](/docs/graphql-ide/how-to-start)
+- [V1 vs V2 API and cloud data](/docs/graphql-ide/v1-and-v2)

--- a/docs/Schema/solana/blocks.md
+++ b/docs/Schema/solana/blocks.md
@@ -1,16 +1,23 @@
 ---
-title: "Solana Blocks API"
-description: "Query Solana blocks data using Bitquery GraphQL API. Get block heights, hashes, timestamps, proposers, and protocol metadata."
-keywords: ["Solana API", "Solana Blocks", "Bitquery", "GraphQL"]
+title: "Solana Blocks API — Slot Height, Hash, Timestamp, Transaction Count"
+description: "Query Solana blocks with Bitquery V1 GraphQL: slot height, parent slot, block hash, timestamp, transaction counts, and aggregated rewards. Built for explorers, throughput monitoring, and slot-correlated reporting."
+keywords:
+  [
+    "Solana blocks API",
+    "Solana slot",
+    "Solana block height",
+    "Solana block hash",
+    "Solana throughput",
+    "Bitquery V1",
+    "Solana GraphQL",
+  ]
 ---
 
 # Blocks
 
-The Blocks API returns information about blocks on the Solana network.
+The Solana **Blocks API** returns indexed metadata for blocks on the Solana network — slot height, parent slot, block hash, timestamp, transaction count, and aggregate rewards. Solana blocks are produced at sub-second intervals by the current leader validator in the slot schedule; each block contains a slot height, parent slot reference, transaction count, block hash, and aggregate rewards distributed to validators and stakers.
 
-Solana blocks are produced at sub-second intervals by the current leader validator in the slot schedule. Each block contains a slot height, parent slot reference, transaction count, block hash, and aggregate rewards distributed to validators and stakers. Use the blocks API for network throughput monitoring, explorer-style recent-block feeds, and correlating on-chain activity to specific slots when analyzing instructions or transfers.
-
-The fields in the schema include: 
+Use the blocks API for **network throughput monitoring**, **explorer-style recent-block feeds**, **slot-correlated reporting**, and as a join key when you need to attach block context to transfers and transactions for audit, accounting, and forensics.
 
 ```
 query ($network: SolanaNetwork!,$from: ISO8601DateTime, $till: ISO8601DateTime) {
@@ -39,35 +46,43 @@ query ($network: SolanaNetwork!,$from: ISO8601DateTime, $till: ISO8601DateTime) 
 }
 ```
 
+## Common use cases
+
+- **Throughput and capacity monitoring** — track transaction count per block to size infra and detect congestion windows.
+- **Explorer feeds** — power "recent blocks" widgets with hash, slot, timestamp, and transaction count.
+- **Audit and slot correlation** — anchor [transfer](/docs/Examples/Solana/transfers) and [transaction](/docs/Examples/Solana/transactions-api) rows to a specific slot/block height for evidence packages.
+- **Validator economics** — combine `rewards` with [Solana block rewards](/docs/Schema/solana/blockRewards) for per-epoch performance views.
+
 <details>
 
 <summary>Filtering Blocks</summary>
 
-
-`rewards`: This field allows you to filter blocks by the amount of rewards they contain. 
+`rewards`: This field allows you to filter blocks by the amount of rewards they contain.
 
 `previousBlockHash`: This field allows you to filter blocks by their previous block hash.
 
-`parentSlot`: This field allows you to filter blocks by their parent slot. 
+`parentSlot`: This field allows you to filter blocks by their parent slot.
 
 `options`: Filter returned data by ordering, limiting, and constraining it.
 
-`height`: This field allows you to filter blocks by their height. 
+`height`: This field allows you to filter blocks by their height.
 
-`date`: This field allows you to filter blocks by their date. 
+`date`: This field allows you to filter blocks by their date.
 
-`blockHash`: This field allows you to filter blocks by their block hash. 
+`blockHash`: This field allows you to filter blocks by their block hash.
 
-`any`: This field allows you to filter blocks by any of the other fields (OR logic). 
+`any`: This field allows you to filter blocks by any of the other fields (OR logic).
 
-`transactionCount`: This field allows you to filter blocks by the number of transactions they contain. 
+`transactionCount`: This field allows you to filter blocks by the number of transactions they contain.
 
 </details>
 
 ## Related Resources
 
-- [Solana schema overview](https://docs.bitquery.io/v1/docs/Schema/solana/overview)
-- [Getting started with the GraphQL IDE](https://docs.bitquery.io/v1/docs/graphql-ide/how-to-start)
-- [Coinpath explained](https://docs.bitquery.io/v1/docs/building-queries/Coinpath-Explained/Overview)
-- [Solana Coinpath API](https://docs.bitquery.io/v1/docs/Schema/solana/coinpath)
-- [GraphQL examples overview](https://docs.bitquery.io/v1/docs/Examples/overview)
+- [Solana transfers schema (V1)](/docs/Schema/solana/transfers) — pair with block height for historical balance reconstruction
+- [Solana transactions schema (V1)](/docs/Schema/solana/transactions) — fees, fee payer, signer in block context
+- [Solana block rewards (V1)](/docs/Schema/solana/blockRewards)
+- [Solana schema overview (V1)](/docs/Schema/solana/overview)
+- [Solana transfers examples (V1)](/docs/Examples/Solana/transfers)
+- [Getting started with the GraphQL IDE](/docs/graphql-ide/how-to-start)
+- [V1 vs V2 API and cloud data](/docs/graphql-ide/v1-and-v2)

--- a/docs/Schema/solana/coinpath.md
+++ b/docs/Schema/solana/coinpath.md
@@ -1,12 +1,24 @@
 ---
-title: "Solana Coinpath API"
-description: "Query Solana coinpath data using Bitquery GraphQL API. Get fund flows, hop paths, and address-level tracing across transfers."
-keywords: ["Solana API", "Solana Coinpath", "Bitquery", "GraphQL"]
+title: "Solana Coinpath API — Multi-Hop SOL & SPL Fund Flow Tracing"
+description: "Trace multi-hop SOL and SPL fund flows on Solana with Bitquery V1 Coinpath GraphQL: inbound/outbound graphs by depth, address, currency, and date. Built for compliance, AML investigations, audit, and forensics."
+keywords:
+  [
+    "Solana Coinpath",
+    "Solana fund flow",
+    "Solana AML",
+    "Solana compliance",
+    "Solana forensics",
+    "Solana investigations",
+    "Bitquery V1",
+    "Solana GraphQL",
+  ]
 ---
 
 # Coinpath
 
-The Solana Coinpath API allows you to get the money flow for an address on the Solana blockchain. You can track any levels of fund movement with this API. This is a very useful API for crypto investigations. 
+The Solana **Coinpath API** traces **multi-hop SOL and SPL fund flows** to and from any Solana address. You can configure depth, direction, currency, and date range to build inbound and outbound graphs of where funds came from and where they went — making it the reference API for **compliance and AML-style investigations**, **audit and forensics**, **incident triage**, and **counterparty risk** workflows.
+
+Coinpath complements the [transfers API](/docs/Schema/solana/transfers): use transfers when you need raw rows or aggregations, and use Coinpath when you need a precomputed, depth-aware flow graph.
 
 ```
 query ($network: SolanaNetwork!, $address: String!, $from: ISO8601DateTime, $till: ISO8601DateTime) {
@@ -83,27 +95,32 @@ query ($network: SolanaNetwork!, $address: String!, $from: ISO8601DateTime, $til
   "till": "2023-08-07T23:59:59",
   "dateFormat": "%Y-%m-%d"
 }
-
 ```
 
+## Common use cases
+
+- **Compliance and AML** — trace inbound funds back N hops from a flagged Solana wallet to identify originating sources, mixers, and exchanges.
+- **Investigations and forensics** — build outbound graphs from incident wallets to follow stolen or laundered SOL/SPL.
+- **Audit and assurance** — produce signed flow graphs as evidence for fund custody and movement reviews.
+- **Counterparty risk** — preview the inbound/outbound counterparty mix before onboarding a Solana address.
+- **Bubble-map style visualization** — pair Coinpath with the [multi-wallet aggregate query](/docs/Examples/Solana/transfers#multi-wallet-aggregates) for visual cluster analysis.
 
 <details>
 
 <summary>Filtering Coinpath</summary>
 
-
 -   **initialAddress**
-    
+
     The address of the account whose coinpath you want to get. The filter can be used to specify the initial address of the coinpath.
-    
+
 -   **depth**
-    
+
     The maximum depth of the coinpath. The filter can be used to specify the maximum depth of the fund flow either inbound and outbound.
-    
+
 -   **options**
-    
+
     A set of options that can be used to filter the results. The following options are supported:
-    
+
     -   **direction**
         -   The direction of the coinpath. The supported directions are  `inbound`  and  `outbound`.
     -   **asc**
@@ -121,31 +138,31 @@ query ($network: SolanaNetwork!, $address: String!, $from: ISO8601DateTime, $til
     -   **seed**
         -   The seed of the coinpath. The seed is a random number that can be used to randomize the order of the coinpath.
 -   **date**
-    
+
     The date range of the coinpath. The filter can be used to specify the start date and end date of the coinpath.
-    
+
 -   **receiver**
-    
+
     The address of the receiver of the transfer. The filter can be used to specify the receiver address of the coinpath.
-    
+
 -   **time**
-    
+
     The timestamp of the transfer. The filter can be used to specify the timestamp of the coinpath.
-    
+
 -   **sender**
-    
+
     The address of the sender of the transfer. The filter can be used to specify the sender address of the coinpath.
-    
+
 -   **currency**
-    
+
     The currency of the transfer. The filter can be used to specify the currency of the coinpath.
-    
+
 -   **initialTime**
-    
+
     The timestamp of the initial transaction. The filter can be used to specify the timestamp of the initial transaction.
-    
+
 -   **initialDate**
-    
+
     The date of the initial transaction. The filter can be used to specify the date of the initial transaction.
 
 </details>
@@ -172,14 +189,15 @@ The currency that was transferred.
 
 The depth of the connection between the two addresses.
 
-
 `signature`
 
 The signature of the transfer.
 
 ## Related Resources
 
-- [Solana schema overview](https://docs.bitquery.io/v1/docs/Schema/solana/overview)
-- [Getting started with the GraphQL IDE](https://docs.bitquery.io/v1/docs/graphql-ide/how-to-start)
-- [Coinpath explained](https://docs.bitquery.io/v1/docs/building-queries/Coinpath-Explained/Overview)
-- [GraphQL examples overview](https://docs.bitquery.io/v1/docs/Examples/overview)
+- [Coinpath explained](/docs/building-queries/Coinpath-Explained/Overview)
+- [Solana transfers schema (V1)](/docs/Schema/solana/transfers)
+- [Solana transfers examples (V1)](/docs/Examples/Solana/transfers) — including [multi-wallet bubble-map aggregates](/docs/Examples/Solana/transfers#multi-wallet-aggregates) and [system-program funding](/docs/Examples/Solana/transfers#system-program-funding)
+- [Solana schema overview (V1)](/docs/Schema/solana/overview)
+- [Getting started with the GraphQL IDE](/docs/graphql-ide/how-to-start)
+- [V1 vs V2 API and cloud data](/docs/graphql-ide/v1-and-v2)

--- a/docs/Schema/solana/instructionAccounts.md
+++ b/docs/Schema/solana/instructionAccounts.md
@@ -1,236 +1,46 @@
 ---
-title: "Solana Instruction Accounts API"
-description: "Query Solana instruction accounts data using Bitquery GraphQL API. Get accounts referenced by each instruction."
-keywords: ["Solana API", "Solana Instruction Accounts", "Bitquery", "GraphQL"]
+title: "Solana Instruction Accounts API (Removed in V1) — Schema Notice"
+description: "The V1 Solana instructionAccounts schema has been removed. Use V2 for per-instruction account metadata, or V1 transfers, transactions, and coinpath."
+keywords:
+  [
+    "Solana instructionAccounts API",
+    "Solana schema",
+    "Bitquery V1",
+    "Solana V2 API",
+    "Solana program accounts",
+    "GraphQL",
+  ]
 ---
 
-# InstructionAccounts
+# InstructionAccounts (Removed in V1)
 
-This API returns information about the accounts involved in an instruction. An instruction is the smallest execution logic on Solana. One transaction can have 1 or more instructions. Below are the fields in the API:
+:::danger Removed in V1 — use the V2 Solana Instructions API
 
-```
-query ($network: SolanaNetwork!, $signature: String!) {
-  solana(network: $network) {
-    instructionAccounts(signature: {is: $signature}) {
-      instruction {
-        action {
-          name
-        }
-        program {
-          parsedName
-        }
-      }
-      account {
-        index
-        name
-        owner
-        type
-      }
-      block {
-        height
-        hash
-        previousBlockHash
-        timestamp {
-          time
-        }
-      }
-      transaction {
-        feePayer
-        signature
-        success
-        transactionIndex
-      }
-    }
-  }
-}
+The Solana `instructionAccounts` query has been **removed from the V1 GraphQL schema** (`graphql.bitquery.io`). The replacement is the **[V2 Solana Instructions API](https://docs.bitquery.io/docs/blockchain/Solana/solana-instructions/)** at `https://streaming.bitquery.io/graphql`, which exposes per-instruction account lists via `Solana.Instructions.Accounts` and balance updates via `Solana.InstructionBalanceUpdates`. This page is kept to preserve inbound links.
 
-<!-- Parameters -->
+:::
 
-{
-  "signature": "19d4fXU8iyMfSkzMadyxzRb9iAkiULA7QYyKPA8rkJP3KPLnhLQLengqj8GpSHVrN4FbCJuFFCgLJc4ifuJjQCs",
-  "network": "solana"
-}
-```
+## Where per-instruction account metadata lives now
 
+Use the **[V2 Solana Instructions API](https://docs.bitquery.io/docs/blockchain/Solana/solana-instructions/)** for parsed instructions and the accounts they touch (`Solana.Instructions.Accounts`, `Solana.InstructionBalanceUpdates`):
 
-<details>
+- V2 Solana Instructions API: [`https://docs.bitquery.io/docs/blockchain/Solana/solana-instructions/`](https://docs.bitquery.io/docs/blockchain/Solana/solana-instructions/)
+- V2 endpoint: `https://streaming.bitquery.io/graphql`
+- V2 docs home: [`https://docs.bitquery.io/`](https://docs.bitquery.io/)
+- See [V1 and V2 endpoints](/docs/graphql-ide/v1-and-v2) for an overview of differences.
 
-<summary>Filtering instructionAccounts</summary>
+For wallet-level activity, fund flow, accounting, and compliance use cases that do not require per-instruction account metas, V1 continues to support:
 
-
-`account`
-
-This field filters the results by the account that was affected by the instruction. You can filter by the account index, name, owner, or type.
-
-`transactionIndex`
-
-This field filters the results by the transaction index of the instruction.
-
-`time`
-
-This field filters the results by the timestamp of the block in which the instruction was included.
-
-`success`
-
-This field filters the results by the success of the transaction that included the instruction.
-
-`signature`
-
-This field filters the results by the signature of the transaction that included the instruction.
-
-`programId`
-
-This field filters the results by the program ID of the program that was used to execute the instruction.
-
-`previousBlockHash`
-
-This field filters the results by the hash of the previous block.
-
-`parsedType`
-
-This field filters the results by the parsed type of the account that was affected by the instruction.
-
-`parsedProgramName`
-
-This field filters the results by the parsed program name of the program that was used to execute the instruction.
-
-`parsedActionName`
-
-This field filters the results by the parsed action name of the action that was performed by the instruction.
-
-`parsed`
-
-This field filters the results by the parsed instruction object.
-
-`options`
-
- Filter returned data by ordering, limiting, and constraining it. Available fields: `asc`, `ascByInteger`, `desc`, `descByInteger`, `limit`, `limitBy`, `offset`.
-
-`height`
-
-This field filters the results by the block height of the block in which the instruction was included.
-
-`feePayer`
-
-This field filters the results by the address of the account that paid the transaction fee.
-
-`fee`
-
-This field filters the results by the transaction fee.
-
-`external`
-
-This field filters the results by whether the instruction was external.
-
-`date`
-
-This field filters the results by the date of the block in which the instruction was included.
-
-`callPath`
-
-This field filters the results by the call path of the instruction.
-
-`blockHash`
-
-This field filters the results by the hash of the block in which the instruction was included.
-
-`any`
-
- A catch-all filter (OR Logic) that can be used to filter the results by any of the other fields.
-group: A filter that groups the results by a specific field.
-
-`accountType`
-
-This field filters the results by the type of the account that was affected by the instruction.
-
-`accountOwner`
-
-This field filters the results by the owner of the account that was affected by the instruction.
-
-`accountIndex`
-
-This field filters the results by the index of the account that was affected by the instruction.
-
-</details>
-
-## Fields
-
--   **instruction**
-    
-    This object contains information about the instruction itself.
-    
-    -   **action**
-        
-        This field contains the name of the action that was performed by the instruction.
-        
-    -   **program**
-        
-        This field contains the name of the program that was used to execute the instruction.
-        
--   **account**
-    
-    This object contains information about the account that was affected by the instruction.
-    
-    -   **index**
-        
-        This field contains the unique identifier for the account.
-        
-    -   **name**
-        
-        This field contains the human-readable name of the account.
-        
-    -   **owner**
-        
-        This field contains the address of the account owner.
-        
-    -   **type**
-        
-        This field contains the type of the account, such as `tokenAccount` or `programAccount`.
-        
--   **block**
-    
-    This object contains information about the block in which the instruction was included.
-    
-    -   **height**
-        
-        This field contains the number of blocks that have been processed since the genesis block.
-        
-    -   **hash**
-        
-        This field contains the unique identifier for the block.
-        
-    -   **previousBlockHash**
-        
-        This field contains the hash of the previous block.
-        
-    -   **timestamp**
-        
-        This field contains the Unix timestamp of the block.
-        
--   **transaction**
-    
-    This object contains information about the transaction that included the instruction.
-    
-    -   **feePayer**
-        
-        This field contains the address of the account that paid the transaction fee.
-        
-    -   **signature**
-        
-        This field contains the cryptographic signature of the transaction.
-        
-    -   **success**
-        
-        This field indicates whether the transaction was successful.
-        
-    -   **transactionIndex**
-        
-        This field is a unique identifier for the transaction within the block.
+- [Solana transfers schema](/docs/Schema/solana/transfers) and [transfers examples](/docs/Examples/Solana/transfers) (full historical SOL and SPL transfers)
+- [Solana transactions schema](/docs/Schema/solana/transactions) and [transactions examples](/docs/Examples/Solana/transactions-api)
+- [Solana address schema](/docs/Schema/solana/address) and [address examples](/docs/Examples/Solana/address-api)
+- [Solana Coinpath schema](/docs/Schema/solana/coinpath) for multi-hop tracing
 
 ## Related Resources
 
-- [Solana schema overview](https://docs.bitquery.io/v1/docs/Schema/solana/overview)
-- [Getting started with the GraphQL IDE](https://docs.bitquery.io/v1/docs/graphql-ide/how-to-start)
-- [Coinpath explained](https://docs.bitquery.io/v1/docs/building-queries/Coinpath-Explained/Overview)
-- [Solana Coinpath API](https://docs.bitquery.io/v1/docs/Schema/solana/coinpath)
-- [GraphQL examples overview](https://docs.bitquery.io/v1/docs/Examples/overview)
+- **[V2 Solana Instructions API (replacement)](https://docs.bitquery.io/docs/blockchain/Solana/solana-instructions/)**
+- [Solana schema overview (V1)](/docs/Schema/solana/overview)
+- [V1 vs V2 API and cloud data](/docs/graphql-ide/v1-and-v2)
+- [Solana transfers schema (V1)](/docs/Schema/solana/transfers)
+- [Solana transfers examples (V1)](/docs/Examples/Solana/transfers)
+- [V2 docs home](https://docs.bitquery.io/)

--- a/docs/Schema/solana/instructions.md
+++ b/docs/Schema/solana/instructions.md
@@ -1,82 +1,46 @@
 ---
-title: "Solana Instructions API"
-description: "Query Solana instructions data using Bitquery GraphQL API. Get program instructions, programs, and instruction-level data."
-keywords: ["Solana API", "Solana Instructions", "Bitquery", "GraphQL"]
+title: "Solana Instructions API (Removed in V1) — Schema Notice"
+description: "The V1 Solana instructions schema has been removed. See V2 for parsed program/instruction analytics, or use V1 transfers, transactions, and coinpath."
+keywords:
+  [
+    "Solana instructions API",
+    "Solana schema",
+    "Bitquery V1",
+    "Solana V2 API",
+    "Solana program analytics",
+    "GraphQL",
+  ]
 ---
 
-# Instructions
+# Instructions (Removed in V1)
 
-The Solana instructions API allows you to query information about instructions that have been executed on the Solana blockchain. This information includes the program that executed the instruction, the accounts that were affected by the instruction, the data that was passed to the instruction, and the log message that was produced by the instruction.
+:::danger Removed in V1 — use the V2 Solana Instructions API
 
-Instructions are the fundamental unit of execution on Solana—every transaction contains one or more instructions, each targeting a specific program (smart contract). Querying at the instruction level lets you analyze DeFi protocol interactions, NFT minting calls, and program-specific logic that transfer-level queries alone cannot reveal. Use this API for program analytics, debugging failed transactions, and building dashboards that break down activity by program and instruction type.
+The Solana `instructions` query has been **removed from the V1 GraphQL schema** (`graphql.bitquery.io`). The replacement is the **[V2 Solana Instructions API](https://docs.bitquery.io/docs/blockchain/Solana/solana-instructions/)** at `https://streaming.bitquery.io/graphql`. This page is kept to preserve inbound links and direct readers to the supported alternative.
 
-The schema includes the following fields:
+:::
 
-```
-query ($network: SolanaNetwork!, $signature: String!) {
-  solana(network: $network) {
-    instructions(signature: {is: $signature}) {
-      program {
-        id
-        name
-        parsedName
-        parsed
-      }
-      accountsCount
-      data {
-        hex
-      }
-      log {
-        consumed
-        logs
-        result
-        totalGas
-        instruction
-      }
-      action {
-        name
-        type
-      }
-      externalAction {
-        type
-        name
-      }
-      externalProgram {
-        id
-        name
-        parsed
-        parsedName
-      }
-      transaction {
-        transactionIndex
-        success
-        signature
-        feePayer
-      }
-    }
-  }
-}
-<!-- Parameters -->
-{
-  "signature": "126VTE4UyQJU7FR68aeaFno11WMYUYX2SRn1dVVT83beQnP3sY2hpHyP2uRgni4u3a2jR2kRnGqs2br2K3V8BkE6",
-  "network": "solana"
-}
+## Where instruction-level data lives now
 
-```
+Use the **[V2 Solana Instructions API](https://docs.bitquery.io/docs/blockchain/Solana/solana-instructions/)** for program-, instruction-, and DEX-trade-level analytics on Solana, including parsed program/method data, account lists, logs, balance update counts, inner instructions, and real-time WebSocket subscriptions.
 
+- V2 Solana Instructions API: [`https://docs.bitquery.io/docs/blockchain/Solana/solana-instructions/`](https://docs.bitquery.io/docs/blockchain/Solana/solana-instructions/)
+- V2 endpoint: `https://streaming.bitquery.io/graphql`
+- V2 docs home: [`https://docs.bitquery.io/`](https://docs.bitquery.io/)
+- See [V1 and V2 endpoints](/docs/graphql-ide/v1-and-v2) for an overview of differences.
 
-<details>
+If you do not need raw instruction parsing, the following V1 surfaces are unchanged and continue to be the recommended path for accounting, audit, trading, compliance, treasury, and bulk-export use cases:
 
-<summary>Filtering Instructions</summary>
-
-</details>
-
-## Fields
+- [Solana transfers schema](/docs/Schema/solana/transfers) and [transfers examples](/docs/Examples/Solana/transfers)
+- [Solana transactions schema](/docs/Schema/solana/transactions) and [transactions examples](/docs/Examples/Solana/transactions-api)
+- [Solana address schema](/docs/Schema/solana/address) and [address examples](/docs/Examples/Solana/address-api)
+- [Solana Coinpath schema](/docs/Schema/solana/coinpath) for multi-hop fund flow
 
 ## Related Resources
 
-- [Solana schema overview](https://docs.bitquery.io/v1/docs/Schema/solana/overview)
-- [Getting started with the GraphQL IDE](https://docs.bitquery.io/v1/docs/graphql-ide/how-to-start)
-- [Coinpath explained](https://docs.bitquery.io/v1/docs/building-queries/Coinpath-Explained/Overview)
-- [Solana Coinpath API](https://docs.bitquery.io/v1/docs/Schema/solana/coinpath)
-- [GraphQL examples overview](https://docs.bitquery.io/v1/docs/Examples/overview)
+- **[V2 Solana Instructions API (replacement)](https://docs.bitquery.io/docs/blockchain/Solana/solana-instructions/)**
+- [Solana schema overview (V1)](/docs/Schema/solana/overview)
+- [V1 vs V2 API and cloud data](/docs/graphql-ide/v1-and-v2)
+- [Solana transfers schema (V1)](/docs/Schema/solana/transfers)
+- [Solana transfers examples (V1)](/docs/Examples/Solana/transfers)
+- [V2 docs home](https://docs.bitquery.io/)

--- a/docs/Schema/solana/overview.md
+++ b/docs/Schema/solana/overview.md
@@ -1,16 +1,13 @@
 ---
 sidebar_position: 1
 title: "Solana API — Blockchain Data Schema | Bitquery"
-description: "Access Solana blockchain data through Bitquery's GraphQL API. Query blocks, transactions, transfers, smart contracts, and more."
+description: "Access Solana blockchain data through Bitquery's GraphQL API: blocks, transactions, full historical SPL and SOL transfers, programs, and Coinpath."
 keywords: [Solana API, Solana GraphQL, Solana blockchain data, Bitquery]
 ---
 
 # Overview
 
-Bitquery API offers access to indexed data from the Solana blockchain. This schema is specifically designed to enable blockchain data retrieval via GraphQL API for developers.
-The schema contains information on blockRewards, address, transfers, transactions, instructions
-and instructionAccounts.
-
+Bitquery's V1 Solana API offers indexed access to the Solana blockchain via GraphQL. The V1 schema is focused on **historical Solana transfers, transactions, addresses, blocks, block rewards, and Coinpath** — the surfaces most often used for accounting, tax, audit, trading research, compliance, treasury, and bulk data delivery.
 
 ```
 query MyQuery {
@@ -27,30 +24,38 @@ Sign up on our **[GraphQL IDE](https://ide.bitquery.io/)** and get your Access T
 
 :::
 
-**Solana** is optimized for **high throughput** and low latency: on-chain programs (often called **programs** rather than “contracts”) receive **instructions**, and each instruction references **instruction accounts** that define which accounts are read or written. **SPL tokens** behave like the chain’s fungible-token standard, and **block rewards** compensate validators for securing the network. Bitquery’s Solana schema surfaces **blocks**, **transactions**, **transfers**, **instructions**, **instruction accounts**, and **coinpath** for flow tracing.
+:::note Instructions on V1 have been retired
+
+V1 no longer exposes the `instructions` and `instructionAccounts` queries for Solana. The replacement is the **[V2 Solana Instructions API](https://docs.bitquery.io/docs/blockchain/Solana/solana-instructions/)** at `https://streaming.bitquery.io/graphql`, which serves program-, instruction-, and DEX-trade-level analytics with parsed methods, account lists, logs, and real-time WebSocket subscriptions — see also the [V2 docs home](https://docs.bitquery.io/) and [V1 vs V2](/docs/graphql-ide/v1-and-v2). All other Solana V1 surfaces below are unchanged.
+
+:::
+
+**Solana** is a high-throughput, low-latency chain whose on-chain **programs** are invoked through **instructions**, and where **SPL tokens** behave as the fungible-token standard. Bitquery's V1 Solana schema indexes **blocks**, **transactions**, full historical **SOL and SPL transfers**, **block rewards**, **addresses**, and **Coinpath** — all the building blocks for wallet, token, and validator analytics that do not require raw instruction parsing.
 
 ## What You Can Query
 
-- **Blocks** — slot-relative structure, block heights or identifiers, timestamps, and aggregates where available
-- **Transactions** — signatures, fee payers, success or failure, and the list of instructions executed in one atomic batch
-- **Instructions** — program IDs, discriminators or decoded types, and the logical operations inside each transaction
-- **Instruction accounts** — per-instruction account metas (writable, signer, addresses) for deep program analytics
-- **Transfers** — native SOL and **SPL token** movements with mints, amounts, and counterparties
-- **Block rewards** — validator reward and fee distribution fields as indexed for staking and economics views
-- **Coinpath** — multi-hop SOL and SPL flows across addresses for tracing funds
+- **Transfers** — native SOL and **SPL token** movements with mints, amounts, counterparties, and program/instruction context where available; **complete historical** transfer rows for accounting, audit, trading, and compliance ([examples](/docs/Examples/Solana/transfers), [schema](/docs/Schema/solana/transfers)). Enterprise **cloud export** (e.g. S3, Parquet) is available for large-scale pipelines — see [V1 vs V2 and cloud data](/docs/graphql-ide/v1-and-v2).
+- **Transactions** — signatures, fee payers, success/failure, signers, instruction counts, fees, and block context ([examples](/docs/Examples/Solana/transactions-api), [schema](/docs/Schema/solana/transactions)).
+- **Address** — wallet SOL balance, annotation, and batched multi-address lookups ([examples](/docs/Examples/Solana/address-api), [schema](/docs/Schema/solana/address)).
+- **Blocks** — slot, height, parent slot, hash, timestamps, transaction counts, and aggregate rewards ([schema](/docs/Schema/solana/blocks)).
+- **Block rewards** — validator and stake account reward distribution per epoch for economics and yield reporting ([schema](/docs/Schema/solana/blockRewards)).
+- **Coinpath** — multi-hop SOL and SPL fund flows across addresses for tracing and forensics ([schema](/docs/Schema/solana/coinpath)).
 
 ## Common Use Cases
 
-- **Program analytics** — break down instruction mix and account usage for DeFi, NFT, or consumer programs
-- **Wallet and SPL portfolios** — aggregate token balances and transfer history per owner or token mint
-- **Validator economics** — combine **block rewards** with transaction fees for performance or yield reporting
-- **Enterprise payment integration** — businesses accepting SOL or SPL tokens for commerce can reconcile high-throughput payment flows with sub-second finality, tying instruction-level data to order systems
-- **Institutional program auditing** — fund administrators and protocol teams can verify program interactions, token mints, and authority changes for governance and risk reporting
+- **Accounting and tax** — reconcile every SOL/SPL credit and debit per wallet, per token, per period using [transfers](/docs/Examples/Solana/transfers#wallet-sender-receiver) and [aggregations](/docs/Examples/Solana/transfers#per-token-sent-received-balance).
+- **Audit and assurance** — produce signed-source-of-record evidence for SOL/SPL movements with [parallel sent and received](/docs/Examples/Solana/transfers#parallel-sent-received-range) and [historical balance](/docs/Examples/Solana/transfers#balance-point-in-time) queries.
+- **Trading research** — discover [first transfer for a mint](/docs/Examples/Solana/transfers#earliest-mint-transfer), [token creators](/docs/Examples/Solana/transfers#earliest-mint-transfer), and program-scoped flows.
+- **Compliance and forensics** — build [bubble-map style multi-wallet aggregates](/docs/Examples/Solana/transfers#multi-wallet-aggregates) and trace funds with [Coinpath](/docs/Schema/solana/coinpath).
+- **Treasury and operations** — monitor inflows and outflows, [funding sources](/docs/Examples/Solana/transfers#system-program-funding), and per-token portfolio activity.
+- **Validator economics** — combine [block rewards](/docs/Schema/solana/blockRewards) with [transaction fees](/docs/Schema/solana/transactions) for performance and yield reporting.
+- **Bulk data delivery** — sync full historical Solana transfers to S3 in **Parquet** for Snowflake, BigQuery, or Databricks pipelines — see [bulk export](/docs/Examples/Solana/transfers#bulk-export-s3-parquet).
 
 ## Related Resources
 
 - [Bitquery documentation intro](https://docs.bitquery.io/v1/docs/intro)
 - [Getting started with the GraphQL IDE](https://docs.bitquery.io/v1/docs/graphql-ide/how-to-start)
+- [Solana transfers examples](https://docs.bitquery.io/v1/docs/Examples/Solana/transfers)
 - [Solana API examples](https://docs.bitquery.io/v1/docs/Examples/Solana)
 - [Ethereum schema overview](https://docs.bitquery.io/v1/docs/Schema/ethereum/overview)
 - [Bitcoin schema overview](https://docs.bitquery.io/v1/docs/Schema/bitcoin/overview)

--- a/docs/Schema/solana/transactions.md
+++ b/docs/Schema/solana/transactions.md
@@ -1,12 +1,24 @@
 ---
-title: "Solana Transactions API"
-description: "Solana txs: signature, fee & feePayer, signer, instruction counts, inner instructions, block slot—GraphQL."
-keywords: ["Solana API", "Solana Transactions", "Bitquery", "GraphQL"]
+title: "Solana Transactions API — Signature, Fee, Fee Payer, Signer, Block Context"
+description: "Query Solana transactions with Bitquery V1 GraphQL: signature, transaction fee, fee payer, signer, success, instruction counts, and full block context. Built for fee analysis, wallet activity, audit, and reconciliation."
+keywords:
+  [
+    "Solana transactions API",
+    "Solana fee payer",
+    "Solana signer",
+    "Solana failed transactions",
+    "Solana audit",
+    "Solana fee analysis",
+    "Bitquery V1",
+    "Solana GraphQL",
+  ]
 ---
 
 # Transactions
 
-The Solana transactions API allows you to query for transactions on the Solana blockchain. You can use this API to get information about specific transactions, such as the signature, block, transaction fee, success, fee payer, inner instructions count, instructions count, signer, and transaction index.
+The Solana **transactions API** on Bitquery V1 returns indexed transaction-level data on the Solana blockchain: **signature**, **block** context, **transactionFee**, **success**, **feePayer**, **innerInstructionsCount**, **instructionsCount**, **signer**, and **transactionIndex** within the block. It covers the full historical chain and is the reference surface for **fee analysis**, **wallet activity reporting**, **audit and reconciliation**, **operations dashboards**, and **failure analytics**.
+
+For raw parsed instruction data, program IDs, or DEX swap decoding, see the **[V2 Solana Instructions API](https://docs.bitquery.io/docs/blockchain/Solana/solana-instructions/)** (also: [V1 vs V2](/docs/graphql-ide/v1-and-v2)).
 
 ```
 query ($network: SolanaNetwork!, $date: ISO8601DateTime, $height: Int) {
@@ -42,10 +54,17 @@ query ($network: SolanaNetwork!, $date: ISO8601DateTime, $height: Int) {
 }
 ```
 
+## Common use cases
+
+- **Fee analysis and capacity planning** — see [transactions in a date range](/docs/Examples/Solana/transactions-api#date-range).
+- **Wallet activity reporting** — fetch [a wallet's signed transactions in a window](/docs/Examples/Solana/transactions-api#wallet-signed-range).
+- **Failure analytics and debugging** — filter to [failed transactions](/docs/Examples/Solana/transactions-api#failed-transactions).
+- **Sponsored transactions and treasuries** — distinguish [fee payer from signer](/docs/Examples/Solana/transactions-api#fee-payer-vs-signer) for relayer cost attribution.
+- **Audit and reconciliation** — pair with [transfers](/docs/Examples/Solana/transfers#parallel-sent-received-range) to attach fee, signer, and success status to every booked movement.
+
 <details>
 
 <summary>Filtering Transactions</summary>
-
 
 `transactionIndex`: This field allows you to filter transactions by their index in the block.
 
@@ -77,17 +96,15 @@ query ($network: SolanaNetwork!, $date: ISO8601DateTime, $height: Int) {
 
 `date`: This field allows you to filter transactions by their date.
 
-blockHash: This field allows you to filter transactions by their block hash.
+`blockHash`: This field allows you to filter transactions by their block hash.
 
-any: This field allows you to filter transactions by any of the other fields in OR condition.
+`any`: This field allows you to filter transactions by any of the other fields in OR condition.
 
-accountsCount: This field allows you to filter transactions by the number of accounts they interact with.
+`accountsCount`: This field allows you to filter transactions by the number of accounts they interact with.
 
 </details>
 
-
 ## Fields
-
 
 `signature`: The signature of the transaction.
 
@@ -109,8 +126,11 @@ accountsCount: This field allows you to filter transactions by the number of acc
 
 ## Related Resources
 
-- [Solana schema overview](https://docs.bitquery.io/v1/docs/Schema/solana/overview)
-- [Getting started with the GraphQL IDE](https://docs.bitquery.io/v1/docs/graphql-ide/how-to-start)
-- [Coinpath explained](https://docs.bitquery.io/v1/docs/building-queries/Coinpath-Explained/Overview)
-- [Solana Coinpath API](https://docs.bitquery.io/v1/docs/Schema/solana/coinpath)
-- [GraphQL examples overview](https://docs.bitquery.io/v1/docs/Examples/overview)
+- [Solana transactions examples (V1)](/docs/Examples/Solana/transactions-api)
+- [Solana transfers schema (V1)](/docs/Schema/solana/transfers)
+- [Solana transfers examples (V1)](/docs/Examples/Solana/transfers)
+- [Solana address schema (V1)](/docs/Schema/solana/address)
+- [Solana schema overview (V1)](/docs/Schema/solana/overview)
+- [Solana Coinpath API (V1)](/docs/Schema/solana/coinpath)
+- [Getting started with the GraphQL IDE](/docs/graphql-ide/how-to-start)
+- [V1 vs V2 API and cloud data](/docs/graphql-ide/v1-and-v2)

--- a/docs/Schema/solana/transfers.md
+++ b/docs/Schema/solana/transfers.md
@@ -1,12 +1,33 @@
 ---
-title: "Solana Transfers API"
-description: "Query Solana transfers data using Bitquery GraphQL API. Get asset transfers, amounts, senders, receivers, and currencies."
-keywords: ["Solana API", "Solana Transfers", "Bitquery", "GraphQL"]
+title: "Solana Transfers API — SPL & SOL | Bitquery GraphQL"
+description: "Solana transfers schema: full historical SOL and SPL token movements, senders, receivers, programs, and aggregates for accounting, audit, trading, and compliance analytics via GraphQL."
+keywords:
+  [
+    "Solana API",
+    "Solana transfers",
+    "SPL token transfers",
+    "Solana GraphQL",
+    "Bitquery",
+    "historical Solana data",
+    "blockchain audit",
+    "Solana compliance",
+    "Parquet export",
+    "wallet transfers",
+  ]
 ---
 
 # Transfers
 
-The transfers API allows you to get a information on transfers that have occurred on the Solana blockchain.Below are the fields in the schema:
+The `transfers` API returns indexed **SOL** and **SPL token** transfer rows on Solana: amounts, counterparties, currency metadata, transaction pointers, block time, and program/instruction context where available. It is the reference surface for **full historical** movement data used in reporting, **audit** evidence, **trading** analytics, and **compliance** workflows. Below is a minimal query shape, then filter reference and field list.
+
+## Common use cases
+
+- **Accounting and tax reporting** — Per-wallet inflows/outflows, period totals, and point-in-time balances (often via aggregates). See [Solana transfers examples](/docs/Examples/Solana/transfers) and [aggregation](/docs/query-features/aggregation/).
+- **Audit and assurance** — Reproducible samples with signature, slot/height, and timestamps; optional bulk datasets for large populations. Examples: [transfers examples](/docs/Examples/Solana/transfers), [expressions](/docs/query-features/expressions/overview).
+- **Trading and research** — Large transfers, funding paths, mint-level history, program-scoped activity. [Examples](/docs/Examples/Solana/transfers).
+- **Compliance and investigations** — Source-of-funds style queries, multi-party aggregates, and [Coinpath](/docs/Schema/solana/coinpath) for multi-hop tracing.
+- **Treasury and operations** — Time-bounded extracts and multi-token views. [Filtering options](/docs/query-features/filtering/options).
+- **Data engineering** — Pagination and aggregates in GraphQL; **S3 / Parquet** and other cloud delivery for warehouse loads. [V1 vs V2 and cloud data](/docs/graphql-ide/v1-and-v2), [streaming product](https://bitquery.io/products/streaming).
 
 ```
 query ($network: SolanaNetwork!, $date: ISO8601DateTime, $height: Int) {
@@ -347,6 +368,7 @@ A catch-all filter (OR Logic) that can be used to filter the results by any of t
 
 ## Related Resources
 
+- [Solana transfers API examples](/docs/Examples/Solana/transfers)
 - [Solana schema overview](https://docs.bitquery.io/v1/docs/Schema/solana/overview)
 - [Getting started with the GraphQL IDE](https://docs.bitquery.io/v1/docs/graphql-ide/how-to-start)
 - [Coinpath explained](https://docs.bitquery.io/v1/docs/building-queries/Coinpath-Explained/Overview)

--- a/docs/graphql-ide/v1-and-v2.md
+++ b/docs/graphql-ide/v1-and-v2.md
@@ -18,6 +18,12 @@ Today we will explain the difference between our V1 and V2 APIs. Let’s start w
 
 If you have any questions please comment on [this community post](https://community.bitquery.io/t/difference-between-bitquery-graphql-v1-and-v2-apis/1561).
 
+:::note Solana on V1
+
+V1 covers full historical **Solana transfers, transactions, addresses, blocks, block rewards, and Coinpath** — see the [Solana schema overview](/docs/Schema/solana/overview) and [Solana transfers examples](/docs/Examples/Solana/transfers). The V1 Solana **`instructions`** and **`instructionAccounts`** queries have been **removed**; parsed Solana instruction-, program-, and DEX-trade-level analytics are now served by the **[V2 Solana Instructions API](https://docs.bitquery.io/docs/blockchain/Solana/solana-instructions/)** at `https://streaming.bitquery.io/graphql`.
+
+:::
+
 ## Endpoints
 
 V1 — https://graphql.bitquery.io/

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -2,9 +2,8 @@
 // Note: type annotations allow type checking and IDEs autocompletion
 require("dotenv").config();
 
-const { themes: prismThemes } = require("prism-react-renderer");
-const lightCodeTheme = prismThemes.github;
-const darkCodeTheme = prismThemes.dracula;
+const lightCodeTheme = require("prism-react-renderer/themes/github");
+const darkCodeTheme = require("prism-react-renderer/themes/dracula");
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {

--- a/sidebars.js
+++ b/sidebars.js
@@ -282,15 +282,13 @@ const sidebars = {
           type: "category",
           label: "Solana",
           items: [
-            "Schema/solana/address",
-            "Schema/solana/blockRewards",
-            "Schema/solana/blocks",
-            "Schema/solana/coinpath",
-            "Schema/solana/instructionAccounts",
-            "Schema/solana/instructions",
             "Schema/solana/overview",
-            "Schema/solana/transactions",
             "Schema/solana/transfers",
+            "Schema/solana/transactions",
+            "Schema/solana/address",
+            "Schema/solana/blocks",
+            "Schema/solana/blockRewards",
+            "Schema/solana/coinpath",
           ],
         },
         {
@@ -415,7 +413,6 @@ const sidebars = {
               type: "category",
               label: "Solana",
               items: [
-                "Examples/Solana/instructions",
                 "Examples/Solana/transfers",
                 "Examples/Solana/transactions-api",
                 "Examples/Solana/address-api",


### PR DESCRIPTION
## Summary

- **Promotes V1 Solana transfers** as the headline V1 Solana surface for accounting, tax, audit, trading research, compliance, treasury, and bulk export — with a use-case-anchor index, expanded variations, and 5 new examples (multi-wallet bubble-map aggregates, parallel sent/received, system-program funding, earliest mint transfer, SPL Token program transfers, and an S3 + Parquet bulk-export section).
- **Retires the V1 Solana `instructions` and `instructionAccounts` APIs**: converts the three corresponding pages (`Examples/Solana/instructions.md`, `Schema/solana/instructions.md`, `Schema/solana/instructionAccounts.md`) into "Removed in V1" notices that preserve the URLs for SEO and redirect to the [V2 Solana Instructions API](https://docs.bitquery.io/docs/blockchain/Solana/solana-instructions/). Drops them from `sidebars.js` and reorders the Solana schema sidebar to lead with **overview → transfers → transactions**. A consistent V2-instructions callout is added to `Schema/solana/overview.md`, `Schema/solana/transactions.md`, `Examples/overview.md`, `Examples/Solana/transactions-api.md`, and `graphql-ide/v1-and-v2.md`.
- **Deeper SEO + use-case pass on remaining V1 Solana docs**: SEO frontmatter, stronger intros, common-use-cases bullets, and refreshed Related Resources on `Schema/solana/{address,blocks,transactions,blockRewards,coinpath}.md`; new examples in `Examples/Solana/transactions-api.md` (failed transactions, fee-payer ≠ signer); decision table in `Examples/Solana/address-api.md`; SEO label/description/keywords on `Examples/Solana/_category_.json`.
- **Build fix**: `docusaurus.config.js` switches to direct `prism-react-renderer` theme requires so the Docusaurus 2.4.3 build succeeds against the installed v1.x package.

## Files changed (18)

- `docs/Examples/Solana/_category_.json`
- `docs/Examples/Solana/address-api.md`
- `docs/Examples/Solana/instructions.md`
- `docs/Examples/Solana/transactions-api.md`
- `docs/Examples/Solana/transfers.md`
- `docs/Examples/overview.md`
- `docs/Schema/solana/address.md`
- `docs/Schema/solana/blockRewards.md`
- `docs/Schema/solana/blocks.md`
- `docs/Schema/solana/coinpath.md`
- `docs/Schema/solana/instructionAccounts.md`
- `docs/Schema/solana/instructions.md`
- `docs/Schema/solana/overview.md`
- `docs/Schema/solana/transactions.md`
- `docs/Schema/solana/transfers.md`
- `docs/graphql-ide/v1-and-v2.md`
- `docusaurus.config.js`
- `sidebars.js`

## Test plan

- [x] \`npm run build\` passes locally with no broken-link errors (1515 docs indexed).
- [x] Editor/markdown lint clean across all touched files.
- [x] All in-repo anchor links to `Examples/Solana/transfers.md` resolve to existing `{#anchor}` IDs.
- [x] Removed `instructions` / `instructionAccounts` URLs still resolve (kept as "Removed in V1" notices) and link to the [V2 Solana Instructions API](https://docs.bitquery.io/docs/blockchain/Solana/solana-instructions/).
- [ ] Reviewer: spot-check the rendered Solana sidebar order (Examples and Schema) and the new Solana transfers anchor index in preview deploy.
- [ ] Reviewer: confirm the "Bulk export to S3 and Parquet" section wording matches the supported cloud-delivery offering.


Made with [Cursor](https://cursor.com)